### PR TITLE
Remove log events query

### DIFF
--- a/projects/observability/src/shared/graphql/request/handlers/traces/trace-graphql-query-handler.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/traces/trace-graphql-query-handler.service.ts
@@ -73,23 +73,7 @@ export class TraceGraphQlQueryHandlerService implements GraphQlQueryHandler<Grap
         children: [
           {
             path: 'results',
-            children: [
-              { path: 'id' },
-              ...(!isEmpty(request.logEventProperties)
-                ? [
-                    {
-                      path: 'logEvents',
-                      children: [
-                        {
-                          path: 'results',
-                          children: this.selectionBuilder.fromSpecifications(request.logEventProperties!)
-                        }
-                      ]
-                    }
-                  ]
-                : []),
-              ...this.selectionBuilder.fromSpecifications(request.spanProperties!)
-            ]
+            children: [{ path: 'id' }, ...this.selectionBuilder.fromSpecifications(request.spanProperties!)]
           }
         ]
       };

--- a/projects/observability/src/shared/services/log-events/log-events.service.test.ts
+++ b/projects/observability/src/shared/services/log-events/log-events.service.test.ts
@@ -38,6 +38,20 @@ describe('Log Events Service', () => {
     ]
   };
 
+  const mockTraceWithoutLogEvents: Trace = {
+    [traceIdKey]: 'test-id',
+    [traceTypeKey]: 'TRACE',
+    spans: [
+      {
+        [spanIdKey]: 'test-span',
+        serviceName: 'service',
+        displaySpanName: 'span',
+        protocolName: 'protocol',
+        startTime: 1608151401295
+      }
+    ]
+  };
+
   const createService = createServiceFactory({
     service: LogEventsService,
     providers: [
@@ -114,5 +128,9 @@ describe('Log Events Service', () => {
       }
     ];
     expect(spectator.service.mapLogEvents(mockTraceWithLogEvents)).toMatchObject(mappedLogEvents);
+  });
+  test('should return empty array for log events', () => {
+    const spectator = createService();
+    expect(spectator.service.mapLogEvents(mockTraceWithoutLogEvents)).toMatchObject([]);
   });
 });

--- a/projects/observability/src/shared/services/log-events/log-events.service.ts
+++ b/projects/observability/src/shared/services/log-events/log-events.service.ts
@@ -65,9 +65,9 @@ export class LogEventsService {
     return (trace.spans ?? [])
       .map((span: Span) => {
         const logEvents = (span.logEvents as Dictionary<LogEvent[]>) ?? {};
-        const results = logEvents.results ?? [];
+        logEvents.results = logEvents.results ?? [];
 
-        return results.map(logEvent => ({
+        return logEvents.results.map(logEvent => ({
           ...logEvent,
           $$spanName: {
             serviceName: trace[traceTypeKey] === ObservabilityTraceType.Api ? span.displayEntityName : span.serviceName,

--- a/projects/observability/src/shared/services/log-events/log-events.service.ts
+++ b/projects/observability/src/shared/services/log-events/log-events.service.ts
@@ -66,6 +66,7 @@ export class LogEventsService {
       .map((span: Span) => {
         const logEvents = (span.logEvents as Dictionary<LogEvent[]>) ?? {};
         const results = logEvents.results ?? [];
+
         return results.map(logEvent => ({
           ...logEvent,
           $$spanName: {

--- a/projects/observability/src/shared/services/log-events/log-events.service.ts
+++ b/projects/observability/src/shared/services/log-events/log-events.service.ts
@@ -63,8 +63,10 @@ export class LogEventsService {
 
   public mapLogEvents(trace: Trace): LogEvent[] {
     return (trace.spans ?? [])
-      .map((span: Span) =>
-        (span.logEvents as Dictionary<LogEvent[]>).results.map(logEvent => ({
+      .map((span: Span) => {
+        const logEvents = (span.logEvents as Dictionary<LogEvent[]>) || {};
+        const results = logEvents.results || [];
+        return results.map(logEvent => ({
           ...logEvent,
           $$spanName: {
             serviceName: trace[traceTypeKey] === ObservabilityTraceType.Api ? span.displayEntityName : span.serviceName,
@@ -72,8 +74,8 @@ export class LogEventsService {
             apiName: span.displaySpanName
           },
           spanStartTime: span.startTime as number
-        }))
-      )
+        }));
+      })
       .flat();
   }
 }

--- a/projects/observability/src/shared/services/log-events/log-events.service.ts
+++ b/projects/observability/src/shared/services/log-events/log-events.service.ts
@@ -64,8 +64,8 @@ export class LogEventsService {
   public mapLogEvents(trace: Trace): LogEvent[] {
     return (trace.spans ?? [])
       .map((span: Span) => {
-        const logEvents = (span.logEvents as Dictionary<LogEvent[]>) || {};
-        const results = logEvents.results || [];
+        const logEvents = (span.logEvents as Dictionary<LogEvent[]>) ?? {};
+        const results = logEvents.results ?? [];
         return results.map(logEvent => ({
           ...logEvent,
           $$spanName: {


### PR DESCRIPTION
## Description
Since we dropped logEvents from the DB we are removing the same from GraphQL queries 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
