### PR TITLE
feat: save Explorer queries to localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "hypertrace-ui",
   "version": "0.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -10493,6 +10493,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -25307,6 +25308,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -26305,6 +26307,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
       "dev": true,
       "dependencies": {
         "@cnakazawa/watch": "^1.0.3",
@@ -27253,6 +27256,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -27300,6 +27304,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -27394,6 +27399,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -27423,6 +27429,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/sourcemap-codec": {
@@ -29596,7 +29603,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
+      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -30182,6 +30189,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -32958,13 +32966,21 @@
         "execa": "^5.0.0"
       },
       "dependencies": {
-        "@ampproject/remapping": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-          "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
           "dev": true,
           "requires": {
-            "@jridgewell/trace-mapping": "^0.3.0"
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "get-stream": {
@@ -33011,100 +33027,33 @@
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "ajv": "8.9.0",
-            "ajv-formats": "2.1.1",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.7",
-            "source-map": "0.7.3"
+            "color-convert": "^2.0.1"
           }
         },
-        "@angular-devkit/schematics": {
-          "version": "13.2.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.2.5.tgz",
-          "integrity": "sha512-kAye6VYiF9JQAoeO+BYhy8eT2QOmhB+WLziRjXoFCBxh5+yXTygTVfs9fD5jmIpHmeu4hd2ErSh69yT5xWcD9g==",
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
-            "@angular-devkit/core": "13.2.5",
-            "jsonc-parser": "3.0.0",
-            "magic-string": "0.25.7",
-            "ora": "5.4.1",
-            "rxjs": "6.6.7"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "@babel/core": {
-          "version": "7.17.5",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
-          "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "@ampproject/remapping": "^2.1.0",
-            "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.3",
-            "@babel/helper-compilation-targets": "^7.16.7",
-            "@babel/helper-module-transforms": "^7.16.7",
-            "@babel/helpers": "^7.17.2",
-            "@babel/parser": "^7.17.3",
-            "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.17.3",
-            "@babel/types": "^7.17.0",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
+            "color-name": "~1.1.4"
           }
         },
-        "@babel/generator": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
-          "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.17.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true
-            }
-          }
-        },
-        "@babel/helper-define-polyfill-provider": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
-          "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-compilation-targets": "^7.13.0",
-            "@babel/helper-module-imports": "^7.12.13",
-            "@babel/helper-plugin-utils": "^7.13.0",
-            "@babel/traverse": "^7.13.0",
-            "debug": "^4.1.1",
-            "lodash.debounce": "^4.0.8",
-            "resolve": "^1.14.2",
-            "semver": "^6.1.2"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
@@ -33559,7 +33508,7 @@
         "chokidar": "^3.5.2",
         "colors": "1.4.0",
         "connect": "^3.7.0",
-        "cors": "^2.8.5",
+        "cors": "latest",
         "event-stream": "4.0.1",
         "faye-websocket": "0.11.x",
         "http-auth": "4.1.9",
@@ -33733,7 +33682,8 @@
     "@graphql-typed-document-node/core": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "requires": {}
     },
     "@hypertrace/hyperdash": {
       "version": "1.2.2",
@@ -34976,7 +34926,8 @@
       "version": "12.2.1",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.2.1.tgz",
       "integrity": "sha512-ks2hfZ5/Ow7luUPetwtlnUuRdSsB7NX56OuTzMhQe6VFoqfvbW8k88Mm5YFcE57wXYNc8Giky28peLO+IQKfpQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -36022,16 +35973,6 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -36082,7 +36023,8 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
       "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -36173,7 +36115,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-formats": {
       "version": "2.1.0",
@@ -36208,7 +36151,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -37623,7 +37567,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
       "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cjs-module-lexer": {
       "version": "0.6.0",
@@ -37813,13 +37758,15 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
           "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@angular/core": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
           "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "aria-query": {
           "version": "3.0.0",
@@ -38323,8 +38270,8 @@
       "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -38438,6 +38385,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -38947,7 +38904,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -41592,7 +41550,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -44348,20 +44307,6 @@
             "jest-message-util": "^25.5.0",
             "jest-util": "^25.5.0",
             "slash": "^3.0.0"
-          },
-          "dependencies": {
-            "@jest/types": {
-              "version": "25.5.0",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-              "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-              "dev": true,
-              "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
-              }
-            }
           }
         },
         "@jest/test-result": {
@@ -44374,54 +44319,18 @@
             "@jest/types": "^25.5.0",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "collect-v8-coverage": "^1.0.0"
-          },
-          "dependencies": {
-            "@jest/types": {
-              "version": "25.5.0",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-              "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-              "dev": true,
-              "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
-              }
-            }
           }
         },
         "@jest/types": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
+            "@types/istanbul-reports": "^1.1.1",
             "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          },
-          "dependencies": {
-            "@types/istanbul-reports": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-              "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-              "dev": true,
-              "requires": {
-                "@types/istanbul-lib-report": "*"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
+            "chalk": "^3.0.0"
           }
         },
         "@types/istanbul-reports": {
@@ -44540,20 +44449,6 @@
             "micromatch": "^4.0.2",
             "slash": "^3.0.0",
             "stack-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "@jest/types": {
-              "version": "25.5.0",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-              "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-              "dev": true,
-              "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
-              }
-            }
           }
         },
         "jest-util": {
@@ -44567,20 +44462,6 @@
             "graceful-fs": "^4.2.4",
             "is-ci": "^2.0.0",
             "make-dir": "^3.0.0"
-          },
-          "dependencies": {
-            "@jest/types": {
-              "version": "25.5.0",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-              "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-              "dev": true,
-              "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
-              }
-            }
           }
         },
         "pretty-format": {
@@ -44593,20 +44474,6 @@
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
-          },
-          "dependencies": {
-            "@jest/types": {
-              "version": "25.5.0",
-              "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-              "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-              "dev": true,
-              "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
-              }
-            }
           }
         },
         "stack-utils": {
@@ -45318,7 +45185,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-preset-angular": {
       "version": "8.4.0",
@@ -46436,6 +46304,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -48961,25 +48839,29 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -49486,7 +49368,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -49558,7 +49441,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -50304,6 +50188,12 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-middleware": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+      "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -52411,6 +52301,23 @@
         "through": "~2.3.4"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -52430,23 +52337,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {
@@ -52495,7 +52385,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
       "integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.0.1",
@@ -54069,6 +53960,15 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -54095,15 +53995,6 @@
                 "ansi-regex": "^4.1.0"
               }
             }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -54454,7 +54345,8 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml": {
       "version": "1.0.1",

--- a/projects/assets-library/src/icons/icon-type.ts
+++ b/projects/assets-library/src/icons/icon-type.ts
@@ -98,6 +98,7 @@ export const enum IconType {
   Remove = 'remove',
   RemoveCircle = 'remove_circle',
   Restore = 'restore',
+  Save = 'save',
   Search = 'svg:search',
   Settings = 'settings',
   Share = 'share',

--- a/projects/common/src/constants/application-constants.ts
+++ b/projects/common/src/constants/application-constants.ts
@@ -1,3 +1,4 @@
 export const enum ApplicationFeature {
-  PageTimeRange = 'ui.page-time-range'
+  PageTimeRange = 'ui.page-time-range',
+  SavedQueries = 'ui.saved-queries'
 }

--- a/projects/components/src/filtering/filter/filter-attribute.ts
+++ b/projects/components/src/filtering/filter/filter-attribute.ts
@@ -7,4 +7,5 @@ export interface FilterAttribute {
   type: FilterAttributeType;
   onlySupportsAggregation?: boolean;
   onlySupportsGrouping?: boolean;
+  scope?: string;
 }

--- a/projects/components/src/filtering/filter/filter-attribute.ts
+++ b/projects/components/src/filtering/filter/filter-attribute.ts
@@ -7,5 +7,4 @@ export interface FilterAttribute {
   type: FilterAttributeType;
   onlySupportsAggregation?: boolean;
   onlySupportsGrouping?: boolean;
-  scope?: string;
 }

--- a/projects/observability/src/pages/explorer/explorer.component.scss
+++ b/projects/observability/src/pages/explorer/explorer.component.scss
@@ -24,7 +24,7 @@
 
   .explorer-filter-bar {
     flex: 0;
-    padding: 0 24px;
+    padding: 0 24px 8px;
   }
 
   .panel-title {
@@ -56,6 +56,11 @@
 
   .explorer-save-button {
     align-self: flex-end;
-    margin-right: 24px;
+    margin: 24px 24px 16px;
+  }
+
+  .explorer-toggle-container {
+    display: flex;
+    justify-content: space-between;
   }
 }

--- a/projects/observability/src/pages/explorer/explorer.component.scss
+++ b/projects/observability/src/pages/explorer/explorer.component.scss
@@ -57,7 +57,5 @@
   .explorer-save-button {
     align-self: flex-end;
     margin-right: 24px;
-
-    border-radius: 6px;
   }
 }

--- a/projects/observability/src/pages/explorer/explorer.component.scss
+++ b/projects/observability/src/pages/explorer/explorer.component.scss
@@ -24,7 +24,7 @@
 
   .explorer-filter-bar {
     flex: 0;
-    padding: 0 24px 8px;
+    padding: 0 24px;
   }
 
   .panel-title {
@@ -52,5 +52,12 @@
     .label {
       @include body-1-medium;
     }
+  }
+
+  .explorer-save-button {
+    align-self: flex-end;
+    margin-right: 24px;
+
+    border-radius: 6px;
   }
 }

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -20,6 +20,7 @@ import {
   FilterBarComponent,
   FilterBuilderLookupService,
   FilterOperator,
+  NotificationService,
   ToggleGroupComponent
 } from '@hypertrace/components';
 import { GraphQlRequestService } from '@hypertrace/graphql-client';
@@ -109,6 +110,9 @@ describe('Explorer component', () => {
       },
       mockProvider(PreferenceService, {
         get: jest.fn().mockReturnValue(of(true))
+      }),
+      mockProvider(NotificationService, {
+        createSuccessToast: jest.fn()
       }),
       ...getMockFlexLayoutProviders()
     ]
@@ -411,5 +415,28 @@ describe('Explorer component', () => {
     expect(spectator.query(ExploreQueryIntervalEditorComponent)?.interval).toEqual(
       new TimeDuration(30, TimeUnit.Second)
     );
+  }));
+
+  test('shows notification when a query is saved successfully', fakeAsync(() => {
+    init();
+    const notificationServiceSpy = spyOn(spectator.inject(NotificationService), 'createSuccessToast');
+
+    /* These selectors should work but don't
+    const saveQueryButton = spectator.query(byText('Save Query'));
+    const saveQueryButton = spectator.query('.explorer-save-button');
+    */
+
+    const saveQueryButton = spectator.query('ht-button');
+
+    expect(saveQueryButton).toExist();
+
+    /* This doesn't give the rendered element, prints a weird object
+    console.log(spectator.element);
+    */
+
+    spectator.click(saveQueryButton as HTMLElement);
+
+    // Below test should pass but doesn't
+    expect(notificationServiceSpy).toHaveBeenCalled();
   }));
 });

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { IconLibraryTestingModule } from '@hypertrace/assets-library';
 import {
   DEFAULT_COLOR_PALETTE,
+  FeatureState,
   FeatureStateResolver,
   LayoutChangeService,
   NavigationService,
@@ -88,7 +89,7 @@ describe('Explorer component', () => {
         query: jest.fn().mockReturnValueOnce(of(mockAttributes)).mockReturnValue(EMPTY)
       }),
       mockProvider(FeatureStateResolver, {
-        getFeatureState: jest.fn().mockReturnValue(of(true))
+        getFeatureState: jest.fn().mockReturnValue(of(FeatureState.Enabled))
       }),
       mockProvider(TimeRangeService, {
         getCurrentTimeRange: () => testTimeRange,
@@ -109,7 +110,7 @@ describe('Explorer component', () => {
         }
       },
       mockProvider(PreferenceService, {
-        get: jest.fn().mockReturnValue(of(true))
+        get: jest.fn().mockReturnValue(of([]))
       }),
       mockProvider(NotificationService, {
         createSuccessToast: jest.fn()
@@ -421,22 +422,10 @@ describe('Explorer component', () => {
     init();
     const notificationServiceSpy = spyOn(spectator.inject(NotificationService), 'createSuccessToast');
 
-    /* These selectors should work but don't
-    const saveQueryButton = spectator.query(byText('Save Query'));
     const saveQueryButton = spectator.query('.explorer-save-button');
-    */
-
-    const saveQueryButton = spectator.query('ht-button');
-
     expect(saveQueryButton).toExist();
 
-    /* This doesn't give the rendered element, prints a weird object
-    console.log(spectator.element);
-    */
-
     spectator.click(saveQueryButton as HTMLElement);
-
-    // Below test should pass but doesn't
-    expect(notificationServiceSpy).toHaveBeenCalled();
+    expect(notificationServiceSpy).toHaveBeenCalledWith('Query Saved Successfully!');
   }));
 });

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -202,7 +202,7 @@ export class ExplorerComponent {
     });
 
     const currentScope =
-      this.filters[0].metadata.scope === SPAN_SCOPE ? ScopeQueryParam.Spans : ScopeQueryParam.EndpointTraces;
+      this.filters[0]?.metadata.scope === SPAN_SCOPE ? ScopeQueryParam.Spans : ScopeQueryParam.EndpointTraces;
     const currentFilters = this.filters.map(filter => filter.urlString);
 
     this.savedQueries.push({ scope: currentScope, filters: currentFilters });

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -194,19 +194,19 @@ export class ExplorerComponent {
     this.featureStateResolver.getFeatureState(ApplicationFeature.SavedQueries).subscribe(featureState => {
       this.enableSavedQueries = featureState === FeatureState.Enabled ? true : false;
     });
-  }
-
-  public onClickSaveQuery(): void {
     this.preferenceService.get('savedQueries', []).subscribe(queries => {
       this.savedQueries = queries as SavedQuery[];
     });
+  }
 
-    const currentScope =
-      this.filters[0]?.metadata.scope === SPAN_SCOPE ? ScopeQueryParam.Spans : ScopeQueryParam.EndpointTraces;
+  public onClickSaveQuery(): void {
+    const currentScope = this.getQueryParamFromContext(
+      this.filters[0]?.metadata.scope as ExplorerGeneratedDashboardContext
+    );
     const currentFilters = this.filters.map(filter => filter.urlString);
 
-    this.savedQueries.push({ scope: currentScope, filters: currentFilters });
-    this.preferenceService.set('savedQueries', this.savedQueries);
+    const newSavedQueries = [...this.savedQueries, { scope: currentScope, filters: currentFilters }];
+    this.preferenceService.set('savedQueries', newSavedQueries);
     this.notificationService.createSuccessToast('Query Saved Successfully!');
   }
 
@@ -227,7 +227,7 @@ export class ExplorerComponent {
     switch (context) {
       case ObservabilityTraceType.Api:
         return ScopeQueryParam.EndpointTraces;
-      case 'SPAN':
+      case SPAN_SCOPE:
         return ScopeQueryParam.Spans;
       default:
         return assertUnreachable(context);

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -203,9 +203,9 @@ export class ExplorerComponent {
 
   public onClickSaveQuery(): void {
     const currentScope = this.getQueryParamFromContext(this.currentContext);
-    const currentFilters = this.filters.map(filter => filter.urlString);
+    const currentFilterUrlStrings = this.filters.map(filter => filter.urlString);
 
-    const newSavedQueries = [...this.savedQueries, { scope: currentScope, filters: currentFilters }];
+    const newSavedQueries = [...this.savedQueries, { scope: currentScope, filterUrlStrings: currentFilterUrlStrings }];
     this.preferenceService.set('savedQueries', newSavedQueries);
     this.notificationService.createSuccessToast('Query Saved Successfully!');
   }
@@ -382,5 +382,5 @@ const enum ExplorerQueryParam {
 
 export interface SavedQuery {
   scope: ScopeQueryParam;
-  filters: string[];
+  filterUrlStrings: string[];
 }

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -6,7 +6,6 @@ import {
   assertUnreachable,
   FeatureState,
   FeatureStateResolver,
-  LocalStorage,
   NavigationService,
   PreferenceService,
   QueryParamObject,
@@ -58,6 +57,7 @@ import {
         [attributes]="this.attributes$ | async"
         [syncWithUrl]="true"
         (filtersChange)="this.onFiltersUpdated($event)"
+        [style.padding-bottom]="enableSavedQueries ? '0' : '8px'"
       ></ht-filter-bar>
 
       <ht-button
@@ -135,6 +135,7 @@ export class ExplorerComponent {
   private static readonly VISUALIZATION_EXPANDED_PREFERENCE: string = 'explorer.visualizationExpanded';
   private static readonly RESULTS_EXPANDED_PREFERENCE: string = 'explorer.resultsExpanded';
   private readonly explorerDashboardBuilder: ExplorerDashboardBuilder;
+  private savedQueries: string[][] = [];
   public readonly resultsDashboard$: Observable<ExplorerGeneratedDashboard>;
   public readonly vizDashboard$: Observable<ExplorerGeneratedDashboard>;
   public readonly initialState$: Observable<InitialExplorerState>;
@@ -167,7 +168,6 @@ export class ExplorerComponent {
 
   public constructor(
     private readonly featureStateResolver: FeatureStateResolver,
-    private readonly localStorage: LocalStorage,
     private readonly metadataService: MetadataService,
     private readonly navigationService: NavigationService,
     private readonly notificationService: NotificationService,
@@ -195,9 +195,12 @@ export class ExplorerComponent {
   }
 
   public onClickSaveQuery(): void {
-    const savedFilters = JSON.parse(this.localStorage.get('preference.savedFilters')?.split('.')[1] ?? '[]');
-    savedFilters.push(this.filters.map(filter => filter.urlString));
-    this.preferenceService.set('savedFilters', savedFilters);
+    this.preferenceService.get('savedQueries', []).subscribe(filters => {
+      this.savedQueries = filters as string[][];
+    });
+
+    this.savedQueries.push(this.filters.map(filter => filter.urlString));
+    this.preferenceService.set('savedQueries', this.savedQueries);
     this.notificationService.createSuccessToast('Query Saved Successfully!');
   }
 

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -138,6 +138,7 @@ export class ExplorerComponent {
   private static readonly RESULTS_EXPANDED_PREFERENCE: string = 'explorer.resultsExpanded';
   private readonly explorerDashboardBuilder: ExplorerDashboardBuilder;
   private savedQueries: SavedQuery[] = [];
+  private currentContext: ExplorerGeneratedDashboardContext = ObservabilityTraceType.Api;
   public readonly resultsDashboard$: Observable<ExplorerGeneratedDashboard>;
   public readonly vizDashboard$: Observable<ExplorerGeneratedDashboard>;
   public readonly initialState$: Observable<InitialExplorerState>;
@@ -197,12 +198,11 @@ export class ExplorerComponent {
     this.preferenceService.get('savedQueries', []).subscribe(queries => {
       this.savedQueries = queries as SavedQuery[];
     });
+    this.currentContext$.subscribe(value => (this.currentContext = value));
   }
 
   public onClickSaveQuery(): void {
-    const currentScope = this.getQueryParamFromContext(
-      this.filters[0]?.metadata.scope as ExplorerGeneratedDashboardContext
-    );
+    const currentScope = this.getQueryParamFromContext(this.currentContext);
     const currentFilters = this.filters.map(filter => filter.urlString);
 
     const newSavedQueries = [...this.savedQueries, { scope: currentScope, filters: currentFilters }];

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -185,11 +185,11 @@ export class ExplorerComponent {
     );
   }
 
-  public onClickSaveQuery() {
+  public onClickSaveQuery(): void {
     const savedFilters = JSON.parse(this.localStorage.get('savedFilters') ?? '');
-    // todo: don't save query if already saved
+    // Todo: don't save query if already saved
     savedFilters.push(this.filters);
-    console.log({ savedFilters, currentQuery: this.filters });
+    // Console.log({ savedFilters, currentQuery: this.filters });
     this.localStorage.set('savedFilters', JSON.stringify(savedFilters));
     this.notificationService.createSuccessToast('Query Saved Successfully!');
   }

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -2,7 +2,10 @@ import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { IconType } from '@hypertrace/assets-library';
 import {
+  ApplicationFeature,
   assertUnreachable,
+  FeatureState,
+  FeatureStateResolver,
   LocalStorage,
   NavigationService,
   PreferenceService,
@@ -61,10 +64,11 @@ import {
         class="explorer-save-button"
         icon="${IconType.Save}"
         label="Save Query"
-        size="${ButtonSize.Small}"
-        (click)="onClickSaveQuery()"
-        [disabled]="filters.length < 1"
         role="tertiary"
+        size="${ButtonSize.Small}"
+        [disabled]="filters.length < 1"
+        (click)="onClickSaveQuery()"
+        *ngIf="enableSavedQueries"
       ></ht-button>
 
       <div class="explorer-content">
@@ -136,6 +140,7 @@ export class ExplorerComponent {
   public readonly initialState$: Observable<InitialExplorerState>;
   public readonly currentContext$: Observable<ExplorerGeneratedDashboardContext>;
   public attributes$: Observable<AttributeMetadata[]> = EMPTY;
+  public enableSavedQueries: boolean = false;
 
   public readonly contextItems: ContextToggleItem[] = [
     {
@@ -161,6 +166,7 @@ export class ExplorerComponent {
   private readonly contextChangeSubject: Subject<ExplorerGeneratedDashboardContext> = new Subject();
 
   public constructor(
+    private readonly featureStateResolver: FeatureStateResolver,
     private readonly localStorage: LocalStorage,
     private readonly metadataService: MetadataService,
     private readonly navigationService: NavigationService,
@@ -183,6 +189,9 @@ export class ExplorerComponent {
       this.initialState$.pipe(map(value => value.contextToggle.value.dashboardContext)),
       this.contextChangeSubject
     );
+    this.featureStateResolver.getFeatureState(ApplicationFeature.SavedQueries).subscribe(featureState => {
+      this.enableSavedQueries = featureState === FeatureState.Enabled ? true : false;
+    });
   }
 
   public onClickSaveQuery(): void {

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -186,11 +186,9 @@ export class ExplorerComponent {
   }
 
   public onClickSaveQuery(): void {
-    const savedFilters = JSON.parse(this.localStorage.get('savedFilters') ?? '');
-    // Todo: don't save query if already saved
-    savedFilters.push(this.filters);
-    // Console.log({ savedFilters, currentQuery: this.filters });
-    this.localStorage.set('savedFilters', JSON.stringify(savedFilters));
+    const savedFilters = JSON.parse(this.localStorage.get('preference.savedFilters')?.split('.')[1] ?? '[]');
+    savedFilters.push(this.filters.map(filter => filter.urlString));
+    this.preferenceService.set('savedFilters', savedFilters);
     this.notificationService.createSuccessToast('Query Saved Successfully!');
   }
 

--- a/projects/observability/src/pages/explorer/explorer.module.ts
+++ b/projects/observability/src/pages/explorer/explorer.module.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { FactorySansProvider, ModuleWithProviders, NgModule } from '@angular/core';
 import {
+  ButtonModule,
   FilterBarModule,
   LetAsyncModule,
+  NotificationModule,
   PageHeaderModule,
   PanelModule,
   ToggleGroupModule
@@ -14,7 +16,9 @@ import { ExplorerComponent } from './explorer.component';
 
 @NgModule({
   imports: [
+    ButtonModule,
     CommonModule,
+    NotificationModule,
     ObservabilityDashboardModule,
     FilterBarModule,
     ExploreQueryEditorModule,

--- a/src/app/shared/feature-resolver/feature-resolver.service.ts
+++ b/src/app/shared/feature-resolver/feature-resolver.service.ts
@@ -8,6 +8,8 @@ export class FeatureResolverService extends FeatureStateResolver {
     switch (flag) {
       case ApplicationFeature.PageTimeRange:
         return of(FeatureState.Disabled);
+      case ApplicationFeature.SavedQueries:
+        return of(FeatureState.Disabled);
       default:
         return of(FeatureState.Enabled);
     }


### PR DESCRIPTION
## Description
Initial PR for implementation of https://github.com/hypertrace/hypertrace-ui/issues/1551

### Testing
- Save Query button only appears when saved-queries feature is enabled.
- Save Query button is disabled if not filters are selected.
- Notification pops up when a query is saved successfully.
- Saved query is available in localStorage.
- Edge case: Saving a query works when no earlier saved preferences are available.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

### Documentation
Not sure if I should update the docs for this feature since we're merging to `rzp_main`.

### Screenshot

<img width="911" alt="Screenshot 2022-05-11 at 12 35 37 PM" src="https://user-images.githubusercontent.com/29686866/167789435-de858f66-dcae-4315-8be1-6c771a113d57.png">

### Errors

```ts
this.notificationService.createSuccessToast('Query Saved Successfully!');
```

This line of code throws the following error in the console, although the notification pops up correctly on the screen.

<img width="1082" alt="Screenshot 2022-05-06 at 8 30 54 AM" src="https://user-images.githubusercontent.com/29686866/167060124-d76de6c2-f3a0-4bc0-9e80-b6e000958ef9.png">

I've created an Issue to discuss this:
https://github.com/hypertrace/hypertrace-ui/issues/1592