### PR TITLE
Load `email` and `name` for analytics purpose from `user-info` endpoint for HyperTrace

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -4,11 +4,18 @@ server {
       location = /graphql {
         proxy_pass http://graphql-service:23431/graphql;
       }
+
+      location = /user-info {
+        default_type application/json;
+        return 200 '{"email":"$http_x_forwarded_email", "name": "$http_x_forwarded_user"}';
+      }
+
       location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
       }
+      
       # redirect server error pages to the static page /50x.html
       #
       error_page   500 502 503 504  /50x.html;

--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -29,13 +29,11 @@ export class RudderStackTelemetry implements UserTelemetryProvider<RudderStackCo
   public identify(): void {
     this.http.get<UserTraits>('/user-info').subscribe(
       (data: UserTraits) => {
-        // tslint:disable-next-line: no-console
-        console.log('user data here ', data);
         identify(data.email, { email: data.email, name: data.name });
       },
-      () => {
+      error => {
         // tslint:disable-next-line: no-console
-        console.error('something went wrong in identify');
+        console.error('something went wrong in identify ', error);
       }
     );
   }

--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -26,12 +26,12 @@ export class RudderStackTelemetry implements UserTelemetryProvider<RudderStackCo
     }
   }
 
-  public identify(userTraits: UserTraits): void {
+  public identify(): void {
     this.http.get<UserTraits>('/user-info').subscribe(
       (data: UserTraits) => {
         // tslint:disable-next-line: no-console
         console.log('user data here ', data);
-        identify(userTraits.email, { email: userTraits.email, name: userTraits.name });
+        identify(data.email, { email: data.email, name: data.name });
       },
       () => {
         // tslint:disable-next-line: no-console


### PR DESCRIPTION
- Updated the `nginx` configuration to include the `/user-info` endpoint which will send across `email` and `name` in JSON format(separate PR to come for `kube-manifests` update to sync the `nginx` conf file)
- Updated `RudderStackTelemetryProvider` to hit `/user-info` endpoint and fetch `email` to be passed forward to `/identify` endpoint of rudderstack.

This PR has been raised for [OBSV-708](https://razorpay.atlassian.net/browse/OBSV-708).