### PR TITLE
[OBSV-641] feat: ask for name before saving a query

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-service.ts
+++ b/projects/observability/src/pages/explorer/explorer-service.ts
@@ -50,7 +50,7 @@ export class ExplorerService {
     );
   }
 
-  public isDuplicateQuery(currentQuery: SavedQuery, savedQueries: SavedQuery[]): boolean {
+  public isDuplicateQuery(currentQuery: Omit<SavedQuery, 'name'>, savedQueries: Omit<SavedQuery, 'name'>[]): boolean {
     for (const savedQuery of savedQueries) {
       if (isEqual(currentQuery, savedQuery)) {
         return true;

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -451,6 +451,7 @@ describe('Explorer component', () => {
   test("doesn't save query if user cancels input dialog", fakeAsync(() => {
     init();
     const preferenceServiceSpy = spyOn(spectator.inject(PreferenceService), 'set');
+    // tslint:disable-next-line: no-null-keyword
     window.prompt = jest.fn().mockReturnValue(null);
 
     const saveQueryButton = spectator.query('.explorer-save-button');

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -433,4 +433,30 @@ describe('Explorer component', () => {
     spectator.click(saveQueryButton as HTMLElement);
     expect(notificationServiceSpy).toHaveBeenCalledWith('Query Saved Successfully!');
   }));
+
+  test('saves query with a default name when no input is provided', fakeAsync(() => {
+    init();
+    const preferenceServiceSpy = spyOn(spectator.inject(PreferenceService), 'set');
+    window.prompt = jest.fn().mockReturnValue('My query');
+
+    const saveQueryButton = spectator.query('.explorer-save-button');
+    expect(saveQueryButton).toExist();
+
+    spectator.click(saveQueryButton as HTMLElement);
+    expect(preferenceServiceSpy).toHaveBeenCalledWith('savedQueries', [
+      { name: 'My query', filters: [], scopeQueryParam: 'endpoint-traces' }
+    ]);
+  }));
+
+  test("doesn't save query if user cancels input dialog", fakeAsync(() => {
+    init();
+    const preferenceServiceSpy = spyOn(spectator.inject(PreferenceService), 'set');
+    window.prompt = jest.fn().mockReturnValue(null);
+
+    const saveQueryButton = spectator.query('.explorer-save-button');
+    expect(saveQueryButton).toExist();
+
+    spectator.click(saveQueryButton as HTMLElement);
+    expect(preferenceServiceSpy).toBeCalledTimes(0);
+  }));
 });

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -227,12 +227,21 @@ export class ExplorerComponent {
 
     const currentQuery = { scopeQueryParam: currentScope, filters: cleanedFilters };
 
-    if (this.explorerService.isDuplicateQuery(currentQuery, this.savedQueries)) {
+    if (
+      this.explorerService.isDuplicateQuery(
+        currentQuery,
+        this.savedQueries.map(({ name, ...rest }) => rest)
+      )
+    ) {
       this.notificationService.createInfoToast('This query is saved already!');
     } else {
-      const newSavedQueries = [...this.savedQueries, currentQuery];
-      this.preferenceService.set('savedQueries', newSavedQueries);
-      this.notificationService.createSuccessToast('Query Saved Successfully!');
+      const queryName = prompt('Please enter a name for this query', 'My query');
+
+      if (queryName !== null) {
+        const newSavedQueries = [...this.savedQueries, { name: queryName, ...currentQuery }];
+        this.preferenceService.set('savedQueries', newSavedQueries);
+        this.notificationService.createSuccessToast('Query Saved Successfully!');
+      }
     }
   }
 
@@ -407,6 +416,7 @@ const enum ExplorerQueryParam {
 }
 
 export interface SavedQuery {
+  name: string;
   scopeQueryParam: ScopeQueryParam;
   filters: Filter[];
 }

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.scss
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.scss
@@ -14,8 +14,6 @@
   }
 
   .query-card {
-    @include raised-shadow-hover();
-
     min-height: 36px;
     width: 100%;
     padding: 8px 10px;
@@ -25,6 +23,7 @@
 
     &:hover {
       cursor: pointer;
+      border: 1px solid $gray-6;
     }
 
     span {

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.ts
@@ -18,7 +18,7 @@ import { SavedQuery } from '../explorer/explorer.component';
         >
           <div class="query-card">
             <div class="name-container">
-              <p class="query-name">></p>
+              <p class="query-name">{{ query.name }}</p>
               <p class="scope">{{ query.scopeQueryParam === 'spans' ? 'Spans' : 'Endpoint Traces' }}</p>
             </div>
             <div class="filters-container">


### PR DESCRIPTION
## Description
A dialog will open up while saving a new query, asking the user to give a name to the query.

### Testing
- Query name defaults to "My query"
- Empty names work
- Custom names work
- Given query name is saved correctly to localStorage
- Given query name is displayed on Saved Queries page

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

### Screenshots

<img width="794" alt="Screenshot 2022-06-09 at 11 43 54 PM" src="https://user-images.githubusercontent.com/29686866/172916200-f3324f90-a8a0-4529-86b4-570e990de8df.png">

<img width="942" alt="Screenshot 2022-06-09 at 11 44 37 PM" src="https://user-images.githubusercontent.com/29686866/172916272-5584829d-9431-4370-b0f2-c8f709b74bd5.png">
