### PR TITLE
[OBSV-726] feat: rename and delete saved queries

### DIFF
--- a/projects/assets-library/src/icons/icon-type.ts
+++ b/projects/assets-library/src/icons/icon-type.ts
@@ -44,6 +44,7 @@ export const enum IconType {
   Download = 'download',
   DrilldownFilter = 'svg:drilldown-filter',
   Edge = 'edge',
+  Edit = 'edit',
   Error = 'error_outline',
   Empty = 'panorama_fish_eye',
   Expand = 'launch',

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -221,7 +221,9 @@ export class ExplorerComponent {
 
     // Remove the undefined subpath field for correct object comparison
     for (const filter of this.filters) {
-      delete filter.subpath;
+      if (filter.subpath === undefined) {
+        delete filter.subpath;
+      }
       cleanedFilters.push(filter);
     }
 

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.scss
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.scss
@@ -13,23 +13,57 @@
     padding: 24px;
   }
 
-  .query-card {
+  .query-container {
+    display: flex;
+  }
+
+  .query-link-container {
+    width: 100%;
+  }
+
+  .query-link {
     min-height: 36px;
     width: 100%;
     padding: 8px 10px;
     border: 1px solid $gray-3;
     border-radius: 6px;
     background-color: $gray-1;
+    transition: 0.2s border-color ease-in;
 
     &:hover {
       cursor: pointer;
-      border: 1px solid $gray-6;
+      border: 1px solid $gray-5;
     }
 
     span {
       background-color: $gray-2;
       border-radius: 4px;
       padding: 0 10px;
+    }
+  }
+
+  .query-options-container {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 2px 0 0 4px;
+  }
+
+  .query-option-edit {
+    transition: 0.2s color ease-in;
+
+    &:hover {
+      cursor: pointer;
+      color: $green-7;
+    }
+  }
+
+  .query-option-delete {
+    transition: 0.2s color ease-in;
+
+    &:hover {
+      cursor: pointer;
+      color: $red-7;
     }
   }
 

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.test.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.test.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { SavedQueriesModule } from '@hypertrace/observability';
+import { ScopeQueryParam } from '../explorer/explorer.component';
 import { SavedQueriesComponent } from './saved-queries.component';
 
 describe('SavedQueriesComponent', () => {
@@ -34,9 +35,25 @@ describe('SavedQueriesComponent', () => {
     expect(component).toBeDefined();
   });
 
-  it('should contain not found text when no saved queries are available', () => {
+  test('should contain not found text when no saved queries are available', () => {
     const debugElement = fixture.debugElement;
     const p = debugElement.query(By.css('.not-found-text')).nativeElement;
     expect(p.textContent).toContain("You haven't saved any queries! Go to Explorer page to save a query.");
+  });
+
+  test('renames a query successfully', () => {
+    component.savedQueries = [{ name: 'Query 1', scopeQueryParam: ScopeQueryParam.Spans, filters: [] }];
+    window.prompt = jest.fn().mockReturnValue('Query 2');
+
+    component.onRename(0);
+    expect(component.savedQueries[0].name).toBe('Query 2');
+  });
+
+  test('deletes a query successfully', () => {
+    component.savedQueries = [{ name: 'Query 1', scopeQueryParam: ScopeQueryParam.Spans, filters: [] }];
+    window.confirm = jest.fn().mockReturnValue(true);
+
+    component.onDelete(0);
+    expect(component.savedQueries.length).toBe(0);
   });
 });

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.ts
@@ -1,31 +1,48 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { NavigationParams, PreferenceService } from '@hypertrace/common';
+import { IconType } from '@hypertrace/assets-library';
+import { NavigationParams, PreferenceService, SubscriptionLifecycle } from '@hypertrace/common';
 import { DrilldownFilter, ExplorerService } from '../explorer/explorer-service';
 import { SavedQuery } from '../explorer/explorer.component';
 
 @Component({
   styleUrls: ['./saved-queries.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [SubscriptionLifecycle],
   template: `
     <div class="saved-queries">
       <ht-page-header></ht-page-header>
       <div class="query-list-container">
-        <ht-link
-          *ngFor="let query of savedQueries$ | async"
-          [paramsOrUrl]="getExplorerNavigationParams$(query) | async"
-        >
-          <div class="query-card">
-            <div class="name-container">
-              <p class="query-name">{{ query.name }}</p>
-              <p class="scope">{{ query.scopeQueryParam === 'spans' ? 'Spans' : 'Endpoint Traces' }}</p>
-            </div>
-            <div class="filters-container">
-              <span *ngFor="let filter of query.filters">{{ filter.userString }}</span>
-            </div>
+        <div class="query-container" *ngFor="let query of savedQueries$ | async; let queryIndex = index">
+          <div class="query-link-container">
+            <ht-link [paramsOrUrl]="getExplorerNavigationParams$(query) | async">
+              <div class="query-link">
+                <div class="name-container">
+                  <p class="query-name">{{ query.name }}</p>
+                  <p class="scope">{{ query.scopeQueryParam === 'spans' ? 'Spans' : 'Endpoint Traces' }}</p>
+                </div>
+                <div class="filters-container">
+                  <span *ngFor="let filter of query.filters">{{ filter.userString }}</span>
+                </div>
+              </div>
+            </ht-link>
           </div>
-        </ht-link>
+          <div class="query-options-container">
+            <ht-icon
+              title="Rename"
+              class="query-option-edit"
+              icon="${IconType.Edit}"
+              (click)="onRename(queryIndex)"
+            ></ht-icon>
+            <ht-icon
+              title="Delete"
+              class="query-option-delete"
+              icon="${IconType.Delete}"
+              (click)="onDelete(queryIndex)"
+            ></ht-icon>
+          </div>
+        </div>
       </div>
       <p class="not-found-text" *ngIf="(savedQueries$ | async)?.length === 0">
         You haven't saved any queries! Go to Explorer page to save a query.
@@ -35,15 +52,44 @@ import { SavedQuery } from '../explorer/explorer.component';
 })
 export class SavedQueriesComponent {
   public savedQueries$: Observable<SavedQuery[]>;
+  public savedQueries: SavedQuery[] = [];
 
   public constructor(
     private readonly preferenceService: PreferenceService,
-    private readonly explorerService: ExplorerService
+    private readonly explorerService: ExplorerService,
+    private readonly subscriptionLifecycle: SubscriptionLifecycle
   ) {
     this.savedQueries$ = this.preferenceService.get('savedQueries', []);
+
+    this.subscriptionLifecycle.add(
+      this.preferenceService.get('savedQueries', []).subscribe((queries: SavedQuery[]) => {
+        this.savedQueries = queries;
+      })
+    );
   }
 
   public getExplorerNavigationParams$(query: SavedQuery): Observable<NavigationParams> {
     return this.explorerService.buildNavParamsWithFilters(query.scopeQueryParam, query.filters as DrilldownFilter[]);
+  }
+
+  public onRename(index: number): void {
+    let queryName: string | null = this.savedQueries[index].name;
+    queryName = prompt('Enter a new name for this query', queryName);
+
+    if (queryName !== null) {
+      this.preferenceService.set(
+        'savedQueries',
+        this.savedQueries.map((query, i) => (i === index ? { ...query, name: queryName } : query))
+      );
+    }
+  }
+
+  public onDelete(index: number): void {
+    if (confirm('Are you sure you want to delete this query?')) {
+      this.preferenceService.set(
+        'savedQueries',
+        this.savedQueries.filter((_, i) => i !== index)
+      );
+    }
   }
 }

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.ts
@@ -14,7 +14,7 @@ import { SavedQuery } from '../explorer/explorer.component';
     <div class="saved-queries">
       <ht-page-header></ht-page-header>
       <div class="query-list-container">
-        <div class="query-container" *ngFor="let query of savedQueries$ | async; let queryIndex = index">
+        <div class="query-container" *ngFor="let query of savedQueries; let queryIndex = index">
           <div class="query-link-container">
             <ht-link [paramsOrUrl]="getExplorerNavigationParams$(query) | async">
               <div class="query-link">
@@ -44,14 +44,13 @@ import { SavedQuery } from '../explorer/explorer.component';
           </div>
         </div>
       </div>
-      <p class="not-found-text" *ngIf="(savedQueries$ | async)?.length === 0">
+      <p class="not-found-text" *ngIf="savedQueries.length === 0">
         You haven't saved any queries! Go to Explorer page to save a query.
       </p>
     </div>
   `
 })
 export class SavedQueriesComponent {
-  public savedQueries$: Observable<SavedQuery[]>;
   public savedQueries: SavedQuery[] = [];
 
   public constructor(
@@ -59,8 +58,6 @@ export class SavedQueriesComponent {
     private readonly explorerService: ExplorerService,
     private readonly subscriptionLifecycle: SubscriptionLifecycle
   ) {
-    this.savedQueries$ = this.preferenceService.get('savedQueries', []);
-
     this.subscriptionLifecycle.add(
       this.preferenceService.get('savedQueries', []).subscribe((queries: SavedQuery[]) => {
         this.savedQueries = queries;

--- a/projects/observability/src/pages/saved-queries/saved-queries.module.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.module.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { LinkModule, PageHeaderModule } from '@hypertrace/components';
+import { IconModule, LinkModule, PageHeaderModule } from '@hypertrace/components';
 
 import { SavedQueriesComponent } from './saved-queries.component';
 
 @NgModule({
-  imports: [CommonModule, PageHeaderModule, LinkModule],
+  imports: [CommonModule, PageHeaderModule, LinkModule, IconModule],
   declarations: [SavedQueriesComponent]
 })
 // tslint:disable-next-line: no-unnecessary-class

--- a/src/app/shared/feature-resolver/feature-resolver.service.ts
+++ b/src/app/shared/feature-resolver/feature-resolver.service.ts
@@ -9,7 +9,7 @@ export class FeatureResolverService extends FeatureStateResolver {
       case ApplicationFeature.PageTimeRange:
         return of(FeatureState.Disabled);
       case ApplicationFeature.SavedQueries:
-        return of(FeatureState.Disabled);
+        return of(FeatureState.Enabled);
       default:
         return of(FeatureState.Enabled);
     }


### PR DESCRIPTION
## Description
Added icon buttons to saved queries enabling the user to rename and delete them individually.

### Testing
- Renaming a query works
- Deleting a query works
- Cancelling the rename dialog leaves the query unaffected
- Cancelling the delete dialog leaves the query unaffected
- Hovering over the icons shows their action as a tooltip

[Test Pipeline](https://deploy.razorpay.com/#/applications/stage-hypertrace/executions?pipeline=Stage-HT-UI-Test) | [Test Environment](https://hypertrace-test.concierge.stage.razorpay.in/explorer?time=1h&scope=endpoint-traces&series=column:count(calls))

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

### Screenshots

<img width="958" alt="Screenshot 2022-06-10 at 4 14 20 PM" src="https://user-images.githubusercontent.com/29686866/173049156-3b149f2e-91a4-4839-8863-acca9ae844c3.png">

<img width="958" alt="Screenshot 2022-06-10 at 4 14 31 PM" src="https://user-images.githubusercontent.com/29686866/173049089-4a744f87-5cb5-4ab0-904e-321c32eecc13.png">

<img width="958" alt="Screenshot 2022-06-10 at 4 14 40 PM" src="https://user-images.githubusercontent.com/29686866/173049106-df286e77-b298-4271-aba8-79447570ddf5.png">
