### PR TITLE
Update Analytics to send same event names with changes in event properties

### DIFF
--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -22,7 +22,7 @@ export class RudderStackTelemetry implements UserTelemetryProvider<RudderStackCo
        */
 
       // tslint:disable-next-line: no-console
-      console.error('Failed to load Rudderstack from here', error);
+      console.error('Failed to load Rudderstack', error);
     }
   }
 

--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -22,7 +22,7 @@ export class RudderStackTelemetry implements UserTelemetryProvider<RudderStackCo
        */
 
       // tslint:disable-next-line: no-console
-      console.error('Failed to load Rudderstack', error);
+      console.error('Failed to load Rudderstack from here', error);
     }
   }
 

--- a/projects/common/src/telemetry/track/track.directive.test.ts
+++ b/projects/common/src/telemetry/track/track.directive.test.ts
@@ -35,10 +35,7 @@ describe('Track directive', () => {
     spectator.click(spectator.element);
     spectator.tick();
 
-    expect(telemetryService.trackEvent).toHaveBeenCalledWith(
-      'click: Content',
-      expect.objectContaining({ type: 'click' })
-    );
+    expect(telemetryService.trackEvent).toHaveBeenCalledWith('mouse-event', expect.objectContaining({ type: 'click' }));
   }));
 
   test('propagates events with custom config', fakeAsync(() => {
@@ -60,7 +57,7 @@ describe('Track directive', () => {
     spectator.tick();
 
     expect(telemetryService.trackEvent).toHaveBeenCalledWith(
-      'mouseover: Content',
+      'mouse-event',
       expect.objectContaining({ type: 'mouseover' })
     );
   }));

--- a/projects/common/src/telemetry/track/track.directive.ts
+++ b/projects/common/src/telemetry/track/track.directive.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit } from '@ang
 import { fromEvent, Subscription } from 'rxjs';
 import { TypedSimpleChanges } from '../../utilities/types/angular-change-object';
 import { TrackUserEventsType } from '../telemetry';
-import { UserTelemetryImplService } from '../user-telemetry-impl.service';
+import { TelemetryEvent, UserTelemetryImplService } from '../user-telemetry-impl.service';
 
 @Directive({
   selector: '[htTrack]'
@@ -57,12 +57,13 @@ export class TrackDirective implements OnInit, OnChanges, OnDestroy {
     this.activeSubscriptions.unsubscribe();
   }
 
-  private trackUserEvent(userEvent: string, eventObj: MouseEvent): void {
+  private trackUserEvent(_userEvent: string, eventObj: MouseEvent): void {
     const targetElement = eventObj.target as HTMLElement;
-    this.userTelemetryImplService.trackEvent(`${userEvent}: ${this.trackedEventLabel}`, {
+    this.userTelemetryImplService.trackEvent(TelemetryEvent.click, {
       tagName: targetElement.tagName,
       className: targetElement.className,
-      type: userEvent
+      type: TelemetryEvent.click,
+      label: this.trackedEventLabel
     });
   }
 }

--- a/projects/common/src/telemetry/track/track.directive.ts
+++ b/projects/common/src/telemetry/track/track.directive.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit } from '@ang
 import { fromEvent, Subscription } from 'rxjs';
 import { TypedSimpleChanges } from '../../utilities/types/angular-change-object';
 import { TrackUserEventsType } from '../telemetry';
-import { TelemetryEvent, UserTelemetryImplService } from '../user-telemetry-impl.service';
+import { UserTelemetryEvent, UserTelemetryImplService } from '../user-telemetry-impl.service';
 
 @Directive({
   selector: '[htTrack]'
@@ -59,7 +59,7 @@ export class TrackDirective implements OnInit, OnChanges, OnDestroy {
 
   private trackUserEvent(userEvent: string, eventObj: MouseEvent): void {
     const targetElement = eventObj.target as HTMLElement;
-    this.userTelemetryImplService.trackEvent(TelemetryEvent.mouseEvent, {
+    this.userTelemetryImplService.trackEvent(UserTelemetryEvent.mouseEvent, {
       tagName: targetElement.tagName,
       className: targetElement.className,
       type: userEvent,

--- a/projects/common/src/telemetry/track/track.directive.ts
+++ b/projects/common/src/telemetry/track/track.directive.ts
@@ -57,12 +57,12 @@ export class TrackDirective implements OnInit, OnChanges, OnDestroy {
     this.activeSubscriptions.unsubscribe();
   }
 
-  private trackUserEvent(_userEvent: string, eventObj: MouseEvent): void {
+  private trackUserEvent(userEvent: string, eventObj: MouseEvent): void {
     const targetElement = eventObj.target as HTMLElement;
-    this.userTelemetryImplService.trackEvent(TelemetryEvent.click, {
+    this.userTelemetryImplService.trackEvent(TelemetryEvent.mouseEvent, {
       tagName: targetElement.tagName,
       className: targetElement.className,
-      type: TelemetryEvent.click,
+      type: userEvent,
       label: this.trackedEventLabel
     });
   }

--- a/projects/common/src/telemetry/user-telemetry-impl.service.test.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.test.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { TelemetryProviderConfig, UserTelemetryProvider, UserTelemetryRegistrationConfig } from './telemetry';
-import { UserTelemetryImplService } from './user-telemetry-impl.service';
+import { TelemetryEvent, UserTelemetryImplService } from './user-telemetry-impl.service';
 
 describe('User Telemetry helper service', () => {
   const injectionToken = new InjectionToken('test-token');
@@ -65,13 +65,17 @@ describe('User Telemetry helper service', () => {
 
     // TrackPage
     spectator.service.trackPageEvent('/abs', { target: 'unknown' });
-    expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', { target: 'unknown', eventCategory: 'page-view' });
+    expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', {
+      target: 'unknown',
+      eventCategory: TelemetryEvent.navigate
+    });
 
     // TrackError
     spectator.service.trackErrorEvent('console error', { target: 'unknown' });
-    expect(telemetryProvider.trackError).toHaveBeenCalledWith('Error: console error', {
+    expect(telemetryProvider.trackError).toHaveBeenCalledWith(TelemetryEvent.error, {
       target: 'unknown',
-      eventCategory: 'error'
+      eventCategory: 'error',
+      errorMessage: 'console error'
     });
   });
 
@@ -118,13 +122,17 @@ describe('User Telemetry helper service', () => {
 
     // TrackPage
     spectator.service.trackPageEvent('/abs', { target: 'unknown' });
-    expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', { target: 'unknown', eventCategory: 'page-view' });
+    expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', {
+      target: 'unknown',
+      eventCategory: TelemetryEvent.navigate
+    });
 
     // TrackError
     spectator.service.trackErrorEvent('console error', { target: 'unknown' });
-    expect(telemetryProvider.trackError).toHaveBeenCalledWith('Error: console error', {
+    expect(telemetryProvider.trackError).toHaveBeenCalledWith(TelemetryEvent.error, {
       target: 'unknown',
-      eventCategory: 'error'
+      eventCategory: 'error',
+      errorMessage: 'console error'
     });
   });
 
@@ -169,7 +177,7 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackEvent('eventA', { target: 'unknown' });
     expect(telemetryProvider.trackEvent).toHaveBeenCalledWith('eventA', {
       target: 'unknown',
-      eventCategory: 'user-action'
+      eventCategory: TelemetryEvent.mouseEvent
     });
 
     // TrackPage
@@ -178,9 +186,10 @@ describe('User Telemetry helper service', () => {
 
     // TrackError
     spectator.service.trackErrorEvent('console error', { target: 'unknown' });
-    expect(telemetryProvider.trackError).toHaveBeenCalledWith('Error: console error', {
+    expect(telemetryProvider.trackError).toHaveBeenCalledWith(TelemetryEvent.error, {
       target: 'unknown',
-      eventCategory: 'error'
+      eventCategory: TelemetryEvent.error,
+      errorMessage: 'console error'
     });
   });
 
@@ -225,12 +234,15 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackEvent('eventA', { target: 'unknown' });
     expect(telemetryProvider.trackEvent).toHaveBeenCalledWith('eventA', {
       target: 'unknown',
-      eventCategory: 'user-action'
+      eventCategory: TelemetryEvent.mouseEvent
     });
 
     // TrackPage
     spectator.service.trackPageEvent('/abs', { target: 'unknown' });
-    expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', { target: 'unknown', eventCategory: 'page-view' });
+    expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', {
+      target: 'unknown',
+      eventCategory: TelemetryEvent.navigate
+    });
 
     // TrackError
     spectator.service.trackPageEvent('console error', { target: 'unknown' });

--- a/projects/common/src/telemetry/user-telemetry-impl.service.test.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.test.ts
@@ -60,7 +60,7 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackEvent('eventA', { target: 'unknown' });
     expect(telemetryProvider.trackEvent).toHaveBeenCalledWith('eventA', {
       target: 'unknown',
-      eventCategory: 'user-action'
+      eventCategory: TelemetryEvent.mouseEvent
     });
 
     // TrackPage

--- a/projects/common/src/telemetry/user-telemetry-impl.service.test.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.test.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { TelemetryProviderConfig, UserTelemetryProvider, UserTelemetryRegistrationConfig } from './telemetry';
-import { TelemetryEvent, UserTelemetryImplService } from './user-telemetry-impl.service';
+import { UserTelemetryEvent, UserTelemetryImplService } from './user-telemetry-impl.service';
 
 describe('User Telemetry helper service', () => {
   const injectionToken = new InjectionToken('test-token');
@@ -60,19 +60,19 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackEvent('eventA', { target: 'unknown' });
     expect(telemetryProvider.trackEvent).toHaveBeenCalledWith('eventA', {
       target: 'unknown',
-      eventCategory: TelemetryEvent.mouseEvent
+      eventCategory: UserTelemetryEvent.mouseEvent
     });
 
     // TrackPage
     spectator.service.trackPageEvent('/abs', { target: 'unknown' });
     expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', {
       target: 'unknown',
-      eventCategory: TelemetryEvent.navigate
+      eventCategory: UserTelemetryEvent.navigate
     });
 
     // TrackError
     spectator.service.trackErrorEvent('console error', { target: 'unknown' });
-    expect(telemetryProvider.trackError).toHaveBeenCalledWith(TelemetryEvent.error, {
+    expect(telemetryProvider.trackError).toHaveBeenCalledWith(UserTelemetryEvent.error, {
       target: 'unknown',
       eventCategory: 'error',
       errorMessage: 'console error'
@@ -124,12 +124,12 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackPageEvent('/abs', { target: 'unknown' });
     expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', {
       target: 'unknown',
-      eventCategory: TelemetryEvent.navigate
+      eventCategory: UserTelemetryEvent.navigate
     });
 
     // TrackError
     spectator.service.trackErrorEvent('console error', { target: 'unknown' });
-    expect(telemetryProvider.trackError).toHaveBeenCalledWith(TelemetryEvent.error, {
+    expect(telemetryProvider.trackError).toHaveBeenCalledWith(UserTelemetryEvent.error, {
       target: 'unknown',
       eventCategory: 'error',
       errorMessage: 'console error'
@@ -177,7 +177,7 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackEvent('eventA', { target: 'unknown' });
     expect(telemetryProvider.trackEvent).toHaveBeenCalledWith('eventA', {
       target: 'unknown',
-      eventCategory: TelemetryEvent.mouseEvent
+      eventCategory: UserTelemetryEvent.mouseEvent
     });
 
     // TrackPage
@@ -186,9 +186,9 @@ describe('User Telemetry helper service', () => {
 
     // TrackError
     spectator.service.trackErrorEvent('console error', { target: 'unknown' });
-    expect(telemetryProvider.trackError).toHaveBeenCalledWith(TelemetryEvent.error, {
+    expect(telemetryProvider.trackError).toHaveBeenCalledWith(UserTelemetryEvent.error, {
       target: 'unknown',
-      eventCategory: TelemetryEvent.error,
+      eventCategory: UserTelemetryEvent.error,
       errorMessage: 'console error'
     });
   });
@@ -234,14 +234,14 @@ describe('User Telemetry helper service', () => {
     spectator.service.trackEvent('eventA', { target: 'unknown' });
     expect(telemetryProvider.trackEvent).toHaveBeenCalledWith('eventA', {
       target: 'unknown',
-      eventCategory: TelemetryEvent.mouseEvent
+      eventCategory: UserTelemetryEvent.mouseEvent
     });
 
     // TrackPage
     spectator.service.trackPageEvent('/abs', { target: 'unknown' });
     expect(telemetryProvider.trackPage).toHaveBeenCalledWith('/abs', {
       target: 'unknown',
-      eventCategory: TelemetryEvent.navigate
+      eventCategory: UserTelemetryEvent.navigate
     });
 
     // TrackError

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -89,3 +89,9 @@ interface UserTelemetryInternalConfig<InitConfig = unknown> {
   enableEventTracking: boolean;
   enableErrorTracking: boolean;
 }
+
+export enum TelemetryEvent {
+  click = "user-action",
+  navigate = "user-navigation",
+  error = "error"
+}

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -47,7 +47,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
     this.initializedTelemetryProviders
       .filter(provider => provider.enableEventTracking)
       .forEach(provider =>
-        provider.telemetryProvider.trackEvent?.(name, { ...data, eventCategory: TelemetryEvent.mouseEvent })
+        provider.telemetryProvider.trackEvent?.(name, { ...data, eventCategory: UserTelemetryEvent.mouseEvent })
       );
   }
 
@@ -55,7 +55,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
     this.initializedTelemetryProviders
       .filter(provider => provider.enablePageTracking)
       .forEach(provider =>
-        provider.telemetryProvider.trackPage?.(url, { ...data, eventCategory: TelemetryEvent.navigate })
+        provider.telemetryProvider.trackPage?.(url, { ...data, eventCategory: UserTelemetryEvent.navigate })
       );
   }
 
@@ -63,9 +63,9 @@ export class UserTelemetryImplService extends UserTelemetryService {
     this.initializedTelemetryProviders
       .filter(provider => provider.enableErrorTracking)
       .forEach(provider =>
-        provider.telemetryProvider.trackError?.(TelemetryEvent.error, {
+        provider.telemetryProvider.trackError?.(UserTelemetryEvent.error, {
           ...data,
-          eventCategory: TelemetryEvent.error,
+          eventCategory: UserTelemetryEvent.error,
           errorMessage: error
         })
       );
@@ -90,7 +90,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
         const queryParamMap = this.router?.routerState.snapshot.root.queryParamMap;
         // Todo - Read from TimeRangeService.TIME_QUERY_PARAM once root cause for test case failure is identified
         const timeParamValue = queryParamMap?.get('time');
-        this.trackPageEvent(TelemetryEvent.navigate, {
+        this.trackPageEvent(UserTelemetryEvent.navigate, {
           url: route.url,
           ...queryParamMap,
           isCustomTime: isCustomTime(timeParamValue !== null ? timeParamValue : undefined)
@@ -107,7 +107,7 @@ interface UserTelemetryInternalConfig<InitConfig = unknown> {
   enableErrorTracking: boolean;
 }
 
-export enum TelemetryEvent {
+export enum UserTelemetryEvent {
   mouseEvent = 'mouse-event',
   navigate = 'user-navigation',
   error = 'error'

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -90,10 +90,14 @@ export class UserTelemetryImplService extends UserTelemetryService {
         const queryParamMap = this.router?.routerState.snapshot.root.queryParamMap;
         // Todo - Read from TimeRangeService.TIME_QUERY_PARAM once root cause for test case failure is identified
         const timeParamValue = queryParamMap?.get('time');
+        const rootObj = this.router?.parseUrl(route.url).root;
+        const urlSegments = rootObj?.children?.primary?.segments.map(segment => segment.path) || [];
         this.trackPageEvent(UserTelemetryEvent.navigate, {
           url: route.url,
           ...queryParamMap,
-          isCustomTime: isCustomTime(timeParamValue !== null ? timeParamValue : undefined)
+          isCustomTime: isCustomTime(timeParamValue !== null ? timeParamValue : undefined),
+          urlSegments: urlSegments,
+          basePath: urlSegments.length >= 0 ? urlSegments[0] : undefined
         });
       });
   }

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -91,7 +91,7 @@ interface UserTelemetryInternalConfig<InitConfig = unknown> {
 }
 
 export enum TelemetryEvent {
-  click = "user-action",
-  navigate = "user-navigation",
-  error = "error"
+  click = 'user-action',
+  navigate = 'user-navigation',
+  error = 'error'
 }

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Injector, Optional } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { delay, filter } from 'rxjs/operators';
-import { FixedTimeRange, TimeRangeService } from '../public-api';
 import { Dictionary } from '../utilities/types/types';
 import { UserTelemetryProvider, UserTelemetryRegistrationConfig, UserTraits } from './telemetry';
 import { UserTelemetryService } from './user-telemetry.service';
@@ -89,11 +88,12 @@ export class UserTelemetryImplService extends UserTelemetryService {
       )
       .subscribe(route => {
         const queryParamMap = this.router?.routerState.snapshot.root.queryParamMap;
-        const timeParamValue = queryParamMap?.get(TimeRangeService.TIME_RANGE_QUERY_PARAM);
+        // Todo - Read from TimeRangeService.TIME_QUERY_PARAM once root cause for test case failure is identified
+        const timeParamValue = queryParamMap?.get('time');
         this.trackPageEvent(TelemetryEvent.navigate, {
           url: route.url,
           ...queryParamMap,
-          isCustomTime: FixedTimeRange.isCustomTime(timeParamValue !== null ? timeParamValue : undefined)
+          isCustomTime: isCustomTime(timeParamValue !== null ? timeParamValue : undefined)
         });
       });
   }
@@ -112,3 +112,9 @@ export enum TelemetryEvent {
   navigate = 'user-navigation',
   error = 'error'
 }
+
+// This is temporary, will move this to fixed-time.range.ts once able to understand why test case was failing
+// This is to move past test case for now
+const isCustomTime = (time: undefined | string): boolean => {
+  return time !== undefined ? /(\d+)-(\d+)/.test(time) : false;
+};

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -48,7 +48,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
     this.initializedTelemetryProviders
       .filter(provider => provider.enableEventTracking)
       .forEach(provider =>
-        provider.telemetryProvider.trackEvent?.(name, { ...data, eventCategory: TelemetryEvent.click })
+        provider.telemetryProvider.trackEvent?.(name, { ...data, eventCategory: TelemetryEvent.mouseEvent })
       );
   }
 
@@ -108,7 +108,7 @@ interface UserTelemetryInternalConfig<InitConfig = unknown> {
 }
 
 export enum TelemetryEvent {
-  click = 'user-action',
+  mouseEvent = 'mouse-event',
   navigate = 'user-navigation',
   error = 'error'
 }

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -115,6 +115,4 @@ export enum UserTelemetryEvent {
 
 // This is temporary, will move this to fixed-time.range.ts once able to understand why test case was failing
 // This is to move past test case for now
-const isCustomTime = (time: undefined | string): boolean => {
-  return time !== undefined ? /(\d+)-(\d+)/.test(time) : false;
-};
+const isCustomTime = (time: undefined | string): boolean => (time !== undefined ? /(\d+)-(\d+)/.test(time) : false);

--- a/projects/common/src/time/fixed-time-range.ts
+++ b/projects/common/src/time/fixed-time-range.ts
@@ -1,9 +1,10 @@
 import { TimeRange } from './time-range';
 
+// Regex denoting custom time range
+const URL_REG_EX: RegExp = /(\d+)-(\d+)/;
+
 export class FixedTimeRange implements TimeRange {
   public static fromUrlString(urlString: string): undefined | FixedTimeRange {
-    const URL_REG_EX: RegExp = /(\d+)-(\d+)/;
-
     const captures = URL_REG_EX.exec(urlString);
     if (!captures || captures.length !== 3) {
       return undefined;
@@ -29,5 +30,9 @@ export class FixedTimeRange implements TimeRange {
   public isCustom(): boolean {
     // Right now all RelativeTimeRanges are NOT custom; all FixedTimeRanges are
     return false;
+  }
+
+  public static isCustomTime(time: undefined | string): boolean {
+    return time !== undefined ? URL_REG_EX.test(time) : false;
   }
 }

--- a/projects/common/src/time/fixed-time-range.ts
+++ b/projects/common/src/time/fixed-time-range.ts
@@ -31,8 +31,4 @@ export class FixedTimeRange implements TimeRange {
     // Right now all RelativeTimeRanges are NOT custom; all FixedTimeRanges are
     return false;
   }
-
-  public static isCustomTime(time: undefined | string): boolean {
-    return time !== undefined ? URL_REG_EX.test(time) : false;
-  }
 }

--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -16,7 +16,7 @@ import { TimeUnit } from './time-unit.type';
   providedIn: 'root'
 })
 export class TimeRangeService {
-  private static readonly TIME_RANGE_QUERY_PARAM: string = 'time';
+  public static readonly TIME_RANGE_QUERY_PARAM: string = 'time';
   private static readonly REFRESH_ON_NAVIGATION: string = 'refresh';
 
   private readonly timeRangeSubject$: ReplaySubject<TimeRange> = new ReplaySubject(1);


### PR DESCRIPTION
**Changes in Analytics to send precise event name for grouping purpose**
- Before, the event names were all unique in nature, hence most analytics tools were not allowing to `group_by` on same type of events, here we have generalised the analytics to three event types - `user-navigation`, `user-click` and `error`.
- Added a `isCustomTime` method to check if the value passed from `param` for `time` is actually a custom time or not, this helps as a filter in analytics.
- Added `TelemetryEvent` enum, which helps to validate that the event type is uniform throughout as mentioned above.
- Sending `basePath` and `urlSegments`, so even nested routes can be queried upon and analytics be done upon the same.
- Example images of dashboards which are to be created in prod using this below.
 
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/56739130/179766525-d1a9c6cb-1a24-4322-b9f7-891c168d2d95.png">
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/56739130/179766874-93686602-3339-48d7-8a8a-7830a711e690.png">
