### PR TITLE
HyperTrace UI Enhancements

### DIFF
--- a/projects/observability/src/pages/apis/api-detail/overview/api-overview.dashboard.ts
+++ b/projects/observability/src/pages/apis/api-detail/overview/api-overview.dashboard.ts
@@ -18,6 +18,7 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
     type: 'container-widget',
     layout: {
       type: 'custom-container-layout',
+      'enable-style': false,
       'column-dimensions': [
         {
           type: 'dimension-model',
@@ -26,29 +27,20 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
         },
         {
           type: 'dimension-model',
-          dimension: 1,
-          unit: 'FR'
-        },
-        {
-          type: 'dimension-model',
-          dimension: 1,
-          unit: 'FR'
+          dimension: 0.2,
+          unit: 'FR',
+          'min-dimension': 345
         }
       ],
       'row-dimensions': [
         {
           type: 'dimension-model',
-          dimension: 88,
+          dimension: 500,
           unit: 'PX'
         },
         {
           type: 'dimension-model',
-          dimension: 320,
-          unit: 'PX'
-        },
-        {
-          type: 'dimension-model',
-          dimension: 640,
+          dimension: 700,
           unit: 'PX'
         }
       ],
@@ -69,24 +61,10 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
         },
         {
           type: 'cell-span-model',
-          'col-start': 2,
-          'col-end': 3,
-          'row-start': 0,
-          'row-end': 1
-        },
-        {
-          type: 'cell-span-model',
           'col-start': 0,
-          'col-end': 3,
+          'col-end': 2,
           'row-start': 1,
           'row-end': 2
-        },
-        {
-          type: 'cell-span-model',
-          'col-start': 0,
-          'col-end': 3,
-          'row-start': 2,
-          'row-end': 3
         }
       ]
     },
@@ -94,611 +72,819 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
       {
         type: 'container-widget',
         layout: {
-          type: 'auto-container-layout',
-          rows: 1,
-          'enable-style': false
-        },
-        children: [
-          {
-            type: 'metric-display-widget',
-            title: 'P99 Latency',
-            subscript: 'ms',
-            data: {
-              type: 'entity-metric-aggregation-data-source',
-              metric: {
-                type: 'metric-aggregation',
-                metric: 'duration',
-                aggregation: MetricAggregationType.P99
-              }
-            }
-          },
-          {
-            type: 'metric-display-widget',
-            title: 'P50 Latency',
-            subscript: 'ms',
-            data: {
-              type: 'entity-metric-aggregation-data-source',
-              metric: {
-                type: 'metric-aggregation',
-                metric: 'duration',
-                aggregation: MetricAggregationType.P50
-              }
-            }
-          }
-        ]
-      },
-      {
-        type: 'container-widget',
-        layout: {
-          type: 'auto-container-layout',
-          rows: 1,
-          'enable-style': false
-        },
-        children: [
-          {
-            type: 'metric-display-widget',
-            title: 'Errors/Second',
-            data: {
-              type: 'entity-metric-aggregation-data-source',
-              metric: {
-                type: 'metric-aggregation',
-                metric: 'errorCount',
-                aggregation: MetricAggregationType.AvgrateSecond
-              }
-            }
-          },
-          {
-            type: 'metric-display-widget',
-            title: 'Total',
-            data: {
-              type: 'entity-metric-aggregation-data-source',
-              metric: {
-                type: 'metric-aggregation',
-                metric: 'errorCount',
-                aggregation: MetricAggregationType.Sum
-              }
-            }
-          }
-        ]
-      },
-      {
-        type: 'container-widget',
-        layout: {
-          type: 'auto-container-layout',
-          rows: 1,
-          'enable-style': false
-        },
-        children: [
-          {
-            type: 'metric-display-widget',
-            title: 'Calls/Second',
-            data: {
-              type: 'entity-metric-aggregation-data-source',
-              metric: {
-                type: 'metric-aggregation',
-                metric: 'numCalls',
-                aggregation: MetricAggregationType.AvgrateSecond
-              }
-            }
-          },
-          {
-            type: 'metric-display-widget',
-            title: 'Total',
-            data: {
-              type: 'entity-metric-aggregation-data-source',
-              metric: {
-                type: 'metric-aggregation',
-                metric: 'numCalls',
-                aggregation: MetricAggregationType.Sum
-              }
-            }
-          }
-        ]
-      },
-      {
-        type: 'container-widget',
-        layout: {
-          type: 'auto-container-layout',
-          rows: 1,
-          'enable-style': false,
-          'grid-gap': '48px'
-        },
-        children: [
-          {
-            type: 'cartesian-widget',
-            title: 'Latency',
-            'selectable-interval': true,
-            'legend-position': LegendPosition.None,
-            'x-axis': {
-              type: 'cartesian-axis',
-              'show-grid-lines': false
+          type: 'custom-container-layout',
+          'column-dimensions': [
+            {
+              type: 'dimension-model',
+              dimension: 1,
+              unit: 'FR'
             },
-            'show-y-axis': true,
-            'y-axis': {
-              type: 'cartesian-axis',
-              'show-grid-lines': true,
-              'min-upper-limit': 25
+            {
+              type: 'dimension-model',
+              dimension: 1,
+              unit: 'FR'
             },
-            'max-series-data-points': 150,
-            bands: [
+            {
+              type: 'dimension-model',
+              dimension: 1,
+              unit: 'FR'
+            }
+          ],
+          'row-dimensions': [
+            {
+              type: 'dimension-model',
+              dimension: 88,
+              unit: 'PX'
+            },
+            {
+              type: 'dimension-model',
+              dimension: 88,
+              unit: 'PX'
+            },
+            {
+              type: 'dimension-model',
+              dimension: 320,
+              unit: 'PX'
+            }
+          ],
+          'cell-spans': [
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 2,
+              'row-start': 0,
+              'row-end': 1
+            },
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 1,
+              'row-start': 1,
+              'row-end': 2
+            },
+            {
+              type: 'cell-span-model',
+              'col-start': 1,
+              'col-end': 2,
+              'row-start': 1,
+              'row-end': 2
+            },
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 3,
+              'row-start': 2,
+              'row-end': 3
+            }
+          ]
+        },
+        children: [
+          {
+            type: 'container-widget',
+            layout: {
+              type: 'auto-container-layout',
+              rows: 1,
+              'enable-style': false
+            },
+            children: [
               {
-                type: 'band',
-                name: 'P99 Baseline',
-                'upper-bound-name': 'P99 Upper Bound',
-                'lower-bound-name': 'P99 Lower Bound',
+                type: 'metric-display-widget',
+                title: 'P99 Latency',
+                subscript: 'ms',
                 data: {
-                  type: 'entity-metric-timeseries-data-source',
+                  type: 'entity-metric-aggregation-data-source',
                   metric: {
-                    type: 'metric-timeseries-band',
-                    metric: 'duration',
-                    aggregation: MetricAggregationType.P99
-                  }
-                }
-              }
-            ],
-            series: [
-              {
-                type: 'series',
-                name: 'p99',
-                'visualization-type': 'line',
-                color: Color.BlueGray4,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
+                    type: 'metric-aggregation',
                     metric: 'duration',
                     aggregation: MetricAggregationType.P99
                   }
                 }
               },
               {
-                type: 'series',
-                name: 'p50',
-                'visualization-type': 'line',
-                color: Color.Blue3,
+                type: 'metric-display-widget',
+                title: 'P95 Latency',
+                subscript: 'ms',
                 data: {
-                  type: 'entity-metric-timeseries-data-source',
+                  type: 'entity-metric-aggregation-data-source',
                   metric: {
-                    type: 'metric-timeseries',
+                    type: 'metric-aggregation',
+                    metric: 'duration',
+                    aggregation: MetricAggregationType.P95
+                  }
+                }
+              },
+              {
+                type: 'metric-display-widget',
+                title: 'P50 Latency',
+                subscript: 'ms',
+                data: {
+                  type: 'entity-metric-aggregation-data-source',
+                  metric: {
+                    type: 'metric-aggregation',
                     metric: 'duration',
                     aggregation: MetricAggregationType.P50
                   }
-                }
-              },
-              {
-                type: 'series',
-                name: 'Errors',
-                'visualization-type': 'line',
-                hide: true,
-                color: Color.Red5,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'errorCount',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'Calls',
-                color: Color.Gray7,
-                'visualization-type': 'line',
-                hide: true,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'numCalls',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              }
-            ],
-            'selection-handler': {
-              type: 'cartesian-explorer-selection-handler'
-            }
-          },
-          {
-            type: 'cartesian-widget',
-            title: 'Errors',
-            'selectable-interval': true,
-            'legend-position': LegendPosition.None,
-            'x-axis': {
-              type: 'cartesian-axis',
-              'show-grid-lines': false
-            },
-            'show-y-axis': true,
-            'y-axis': {
-              type: 'cartesian-axis',
-              'show-grid-lines': true,
-              'min-upper-limit': 25
-            },
-            'max-series-data-points': 150,
-            bands: [
-              {
-                type: 'band',
-                name: 'Errors Baseline',
-                'upper-bound-name': 'Errors Upper Bound',
-                'lower-bound-name': 'Errors Lower Bound',
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries-band',
-                    metric: 'errorCount',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              }
-            ],
-            series: [
-              {
-                type: 'series',
-                name: 'Errors',
-                'visualization-type': 'line',
-                color: Color.Red5,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'errorCount',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'p99 Latency',
-                'visualization-type': 'line',
-                color: Color.BlueGray4,
-                hide: true,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'duration',
-                    aggregation: MetricAggregationType.P99
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'p50 Latency',
-                hide: true,
-                'visualization-type': 'line',
-                color: Color.Blue3,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'duration',
-                    aggregation: MetricAggregationType.P50
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'Calls',
-                hide: true,
-                color: Color.Gray7,
-                'visualization-type': 'line',
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'numCalls',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              }
-            ],
-            'selection-handler': {
-              type: 'cartesian-explorer-selection-handler'
-            }
-          },
-          {
-            type: 'cartesian-widget',
-            title: 'Calls',
-            'selectable-interval': true,
-            'legend-position': LegendPosition.None,
-            'x-axis': {
-              type: 'cartesian-axis',
-              'show-grid-lines': false
-            },
-            'show-y-axis': true,
-            'y-axis': {
-              type: 'cartesian-axis',
-              'show-grid-lines': true,
-              'min-upper-limit': 25
-            },
-            'max-series-data-points': 150,
-            bands: [
-              {
-                type: 'band',
-                name: 'Calls Baseline',
-                'upper-bound-name': 'Calls Upper Bound',
-                'lower-bound-name': 'Calls Lower Bound',
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries-band',
-                    metric: 'numCalls',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              }
-            ],
-            series: [
-              {
-                type: 'series',
-                name: 'Calls',
-                color: Color.Gray7,
-                'visualization-type': 'line',
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'numCalls',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'p99 Latency',
-                hide: true,
-                'visualization-type': 'line',
-                color: Color.BlueGray4,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'duration',
-                    aggregation: MetricAggregationType.P99
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'p50 Latency',
-                hide: true,
-                'visualization-type': 'line',
-                color: Color.Blue3,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'duration',
-                    aggregation: MetricAggregationType.P50
-                  }
-                }
-              },
-              {
-                type: 'series',
-                name: 'Errors',
-                'visualization-type': 'line',
-                hide: true,
-                color: Color.Red5,
-                data: {
-                  type: 'entity-metric-timeseries-data-source',
-                  metric: {
-                    type: 'metric-timeseries',
-                    metric: 'errorCount',
-                    aggregation: MetricAggregationType.Sum
-                  }
-                }
-              }
-            ],
-            'selection-handler': {
-              type: 'cartesian-explorer-selection-handler'
-            }
-          }
-        ]
-      },
-      {
-        type: 'topology-widget',
-        title: 'Dependency Graph',
-        data: {
-          type: 'topology-data-source',
-          'upstream-entities': ['SERVICE'],
-          'downstream-entities': ['API', 'BACKEND'],
-          entity: 'API',
-          'node-metrics': {
-            type: 'topology-metrics',
-            primary: {
-              type: 'topology-metric-with-category',
-              specification: {
-                type: 'percentile-latency-metric-aggregation',
-                'display-name': 'P99 Latency'
-              },
-              categories: [
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryNodeMetricCategories[0]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryNodeMetricCategories[1]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryNodeMetricCategories[2]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryNodeMetricCategories[3]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryNodeMetricCategories[4]
-                }
-              ]
-            },
-            secondary: {
-              type: 'topology-metric-with-category',
-              specification: {
-                type: 'error-percentage-metric-aggregation',
-                aggregation: MetricAggregationType.Average,
-                'display-name': 'Error %'
-              },
-              categories: [
-                {
-                  type: 'topology-metric-category',
-                  ...defaultSecondaryNodeMetricCategories[0]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultSecondaryNodeMetricCategories[1]
-                }
-              ]
-            },
-            others: [
-              {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'duration',
-                  aggregation: MetricAggregationType.P50,
-                  'display-name': 'P50 Latency'
-                }
-              },
-              {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'errorCount',
-                  aggregation: MetricAggregationType.Sum,
-                  'display-name': 'Errors'
-                }
-              },
-              {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'errorCount',
-                  aggregation: MetricAggregationType.AvgrateSecond,
-                  'display-name': 'Errors/s'
-                }
-              },
-              {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'numCalls',
-                  aggregation: MetricAggregationType.Sum,
-                  'display-name': 'Calls'
-                }
-              },
-              {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'numCalls',
-                  aggregation: MetricAggregationType.AvgrateSecond,
-                  'display-name': 'Calls/s'
                 }
               }
             ]
           },
-          'edge-metrics': {
-            type: 'topology-metrics',
-            primary: {
-              type: 'topology-metric-with-category',
-              specification: {
-                type: 'percentile-latency-metric-aggregation',
-                'display-name': 'P99 Latency'
-              },
-              categories: [
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryEdgeMetricCategories[0]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryEdgeMetricCategories[1]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryEdgeMetricCategories[2]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryEdgeMetricCategories[3]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultPrimaryEdgeMetricCategories[4]
-                }
-              ]
+          {
+            type: 'container-widget',
+            layout: {
+              type: 'auto-container-layout',
+              rows: 1,
+              'enable-style': false
             },
-            secondary: {
-              type: 'topology-metric-with-category',
-              specification: {
-                type: 'error-percentage-metric-aggregation',
-                aggregation: MetricAggregationType.Average,
-                'display-name': 'Error %'
-              },
-              categories: [
-                {
-                  type: 'topology-metric-category',
-                  ...defaultSecondaryEdgeMetricCategories[0]
-                },
-                {
-                  type: 'topology-metric-category',
-                  ...defaultSecondaryEdgeMetricCategories[1]
+            children: [
+              {
+                type: 'metric-display-widget',
+                title: 'Errors/Second',
+                data: {
+                  type: 'entity-metric-aggregation-data-source',
+                  metric: {
+                    type: 'metric-aggregation',
+                    metric: 'errorCount',
+                    aggregation: MetricAggregationType.AvgrateSecond
+                  }
                 }
-              ]
+              },
+              {
+                type: 'metric-display-widget',
+                title: 'Total',
+                data: {
+                  type: 'entity-metric-aggregation-data-source',
+                  metric: {
+                    type: 'metric-aggregation',
+                    metric: 'errorCount',
+                    aggregation: MetricAggregationType.Sum
+                  }
+                }
+              }
+            ]
+          },
+          {
+            type: 'container-widget',
+            layout: {
+              type: 'auto-container-layout',
+              rows: 1,
+              'enable-style': false
             },
-            others: [
+            children: [
               {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'duration',
-                  aggregation: MetricAggregationType.P50,
-                  'display-name': 'P50 Latency'
+                type: 'metric-display-widget',
+                title: 'Calls/Second',
+                data: {
+                  type: 'entity-metric-aggregation-data-source',
+                  metric: {
+                    type: 'metric-aggregation',
+                    metric: 'numCalls',
+                    aggregation: MetricAggregationType.AvgrateSecond
+                  }
                 }
               },
               {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'errorCount',
-                  aggregation: MetricAggregationType.Sum,
-                  'display-name': 'Errors'
+                type: 'metric-display-widget',
+                title: 'Total',
+                data: {
+                  type: 'entity-metric-aggregation-data-source',
+                  metric: {
+                    type: 'metric-aggregation',
+                    metric: 'numCalls',
+                    aggregation: MetricAggregationType.Sum
+                  }
+                }
+              }
+            ]
+          },
+          {
+            type: 'container-widget',
+            layout: {
+              type: 'auto-container-layout',
+              rows: 1,
+              'enable-style': false,
+              'grid-gap': '48px'
+            },
+            children: [
+              {
+                type: 'cartesian-widget',
+                title: 'Latency',
+                'selectable-interval': true,
+                'legend-position': LegendPosition.None,
+                'x-axis': {
+                  type: 'cartesian-axis',
+                  'show-grid-lines': false
+                },
+                'show-y-axis': true,
+                'y-axis': {
+                  type: 'cartesian-axis',
+                  'show-grid-lines': true,
+                  'min-upper-limit': 25
+                },
+                'max-series-data-points': 150,
+                bands: [
+                  {
+                    type: 'band',
+                    name: 'P99 Baseline',
+                    'upper-bound-name': 'P99 Upper Bound',
+                    'lower-bound-name': 'P99 Lower Bound',
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries-band',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P99
+                      }
+                    }
+                  }
+                ],
+                series: [
+                  {
+                    type: 'series',
+                    name: 'p99',
+                    'visualization-type': 'line',
+                    color: Color.BlueGray4,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P99
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'p50',
+                    'visualization-type': 'line',
+                    color: Color.Blue3,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P50
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'Errors',
+                    'visualization-type': 'line',
+                    hide: true,
+                    color: Color.Red5,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'errorCount',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'Calls',
+                    color: Color.Gray7,
+                    'visualization-type': 'line',
+                    hide: true,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'numCalls',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  }
+                ],
+                'selection-handler': {
+                  type: 'cartesian-explorer-selection-handler'
                 }
               },
               {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'errorCount',
-                  aggregation: MetricAggregationType.AvgrateSecond,
-                  'display-name': 'Errors/s'
+                type: 'cartesian-widget',
+                title: 'Errors',
+                'selectable-interval': true,
+                'legend-position': LegendPosition.None,
+                'x-axis': {
+                  type: 'cartesian-axis',
+                  'show-grid-lines': false
+                },
+                'show-y-axis': true,
+                'y-axis': {
+                  type: 'cartesian-axis',
+                  'show-grid-lines': true,
+                  'min-upper-limit': 25
+                },
+                'max-series-data-points': 150,
+                bands: [
+                  {
+                    type: 'band',
+                    name: 'Errors Baseline',
+                    'upper-bound-name': 'Errors Upper Bound',
+                    'lower-bound-name': 'Errors Lower Bound',
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries-band',
+                        metric: 'errorCount',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  }
+                ],
+                series: [
+                  {
+                    type: 'series',
+                    name: 'Errors',
+                    'visualization-type': 'line',
+                    color: Color.Red5,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'errorCount',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'p99 Latency',
+                    'visualization-type': 'line',
+                    color: Color.BlueGray4,
+                    hide: true,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P99
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'p50 Latency',
+                    hide: true,
+                    'visualization-type': 'line',
+                    color: Color.Blue3,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P50
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'Calls',
+                    hide: true,
+                    color: Color.Gray7,
+                    'visualization-type': 'line',
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'numCalls',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  }
+                ],
+                'selection-handler': {
+                  type: 'cartesian-explorer-selection-handler'
                 }
               },
               {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'numCalls',
-                  aggregation: MetricAggregationType.Sum,
-                  'display-name': 'Calls'
-                }
-              },
-              {
-                type: 'topology-metric-with-category',
-                specification: {
-                  type: 'metric-aggregation',
-                  metric: 'numCalls',
-                  aggregation: MetricAggregationType.AvgrateSecond,
-                  'display-name': 'Calls/s'
+                type: 'cartesian-widget',
+                title: 'Calls',
+                'selectable-interval': true,
+                'legend-position': LegendPosition.None,
+                'x-axis': {
+                  type: 'cartesian-axis',
+                  'show-grid-lines': false
+                },
+                'show-y-axis': true,
+                'y-axis': {
+                  type: 'cartesian-axis',
+                  'show-grid-lines': true,
+                  'min-upper-limit': 25
+                },
+                'max-series-data-points': 150,
+                bands: [
+                  {
+                    type: 'band',
+                    name: 'Calls Baseline',
+                    'upper-bound-name': 'Calls Upper Bound',
+                    'lower-bound-name': 'Calls Lower Bound',
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries-band',
+                        metric: 'numCalls',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  }
+                ],
+                series: [
+                  {
+                    type: 'series',
+                    name: 'Calls',
+                    color: Color.Gray7,
+                    'visualization-type': 'line',
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'numCalls',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'p99 Latency',
+                    hide: true,
+                    'visualization-type': 'line',
+                    color: Color.BlueGray4,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P99
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'p50 Latency',
+                    hide: true,
+                    'visualization-type': 'line',
+                    color: Color.Blue3,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'duration',
+                        aggregation: MetricAggregationType.P50
+                      }
+                    }
+                  },
+                  {
+                    type: 'series',
+                    name: 'Errors',
+                    'visualization-type': 'line',
+                    hide: true,
+                    color: Color.Red5,
+                    data: {
+                      type: 'entity-metric-timeseries-data-source',
+                      metric: {
+                        type: 'metric-timeseries',
+                        metric: 'errorCount',
+                        aggregation: MetricAggregationType.Sum
+                      }
+                    }
+                  }
+                ],
+                'selection-handler': {
+                  type: 'cartesian-explorer-selection-handler'
                 }
               }
             ]
           }
-        }
+        ]
+      },
+      {
+        type: 'container-widget',
+        layout: {
+          type: 'custom-container-layout',
+          'column-dimensions': [
+            {
+              type: 'dimension-model',
+              dimension: 1,
+              unit: 'FR'
+            }
+          ],
+          'row-dimensions': [
+            {
+              type: 'dimension-model',
+              dimension: 424,
+              unit: 'PX'
+            },
+            {
+              type: 'dimension-model',
+              dimension: 640,
+              unit: 'PX'
+            }
+          ],
+          'cell-spans': [
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 1,
+              'row-start': 0,
+              'row-end': 1
+            },
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 1,
+              'row-start': 1,
+              'row-end': 2
+            }
+          ]
+        },
+        children: [
+          {
+            type: 'radar-widget',
+            title: 'Health',
+            levels: 8,
+            series: {
+              type: 'radar-series',
+              name: 'Current Time Range',
+              color: Color.Gray7
+            },
+            data: {
+              type: 'entity-radar-data-source',
+              metrics: [
+                {
+                  type: 'percentile-latency-metric-aggregation',
+                  'display-name': 'P99 Latency'
+                },
+                {
+                  type: 'metric-aggregation',
+                  metric: 'duration',
+                  aggregation: MetricAggregationType.P50,
+                  'display-name': 'P50 Latency'
+                },
+                {
+                  type: 'error-percentage-metric-aggregation',
+                  aggregation: MetricAggregationType.Average,
+                  'display-name': 'Error %'
+                },
+
+                {
+                  type: 'metric-aggregation',
+                  metric: 'errorCount',
+                  aggregation: MetricAggregationType.Sum,
+                  'display-name': 'Error Count'
+                },
+                {
+                  type: 'metric-aggregation',
+                  metric: 'numCalls',
+                  aggregation: MetricAggregationType.AvgrateSecond,
+                  'display-name': 'Call Rate/sec'
+                },
+                {
+                  type: 'metric-aggregation',
+                  metric: 'numCalls',
+                  aggregation: MetricAggregationType.Sum,
+                  'display-name': 'Call Count'
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        type: 'container-widget',
+        layout: {
+          type: 'custom-container-layout',
+          'column-dimensions': [
+            {
+              type: 'dimension-model',
+              dimension: 1,
+              unit: 'FR'
+            }
+          ],
+          'row-dimensions': [
+            {
+              type: 'dimension-model',
+              dimension: 640,
+              unit: 'PX'
+            }
+          ],
+          'cell-spans': [
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 1,
+              'row-start': 0,
+              'row-end': 1
+            }
+          ]
+        },
+        children: [
+          {
+            type: 'topology-widget',
+            title: 'Dependency Graph',
+            data: {
+              type: 'topology-data-source',
+              'upstream-entities': ['SERVICE'],
+              'downstream-entities': ['API', 'BACKEND'],
+              entity: 'API',
+              'node-metrics': {
+                type: 'topology-metrics',
+                primary: {
+                  type: 'topology-metric-with-category',
+                  specification: {
+                    type: 'percentile-latency-metric-aggregation',
+                    'display-name': 'P99 Latency'
+                  },
+                  categories: [
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryNodeMetricCategories[0]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryNodeMetricCategories[1]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryNodeMetricCategories[2]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryNodeMetricCategories[3]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryNodeMetricCategories[4]
+                    }
+                  ]
+                },
+                secondary: {
+                  type: 'topology-metric-with-category',
+                  specification: {
+                    type: 'error-percentage-metric-aggregation',
+                    aggregation: MetricAggregationType.Average,
+                    'display-name': 'Error %'
+                  },
+                  categories: [
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultSecondaryNodeMetricCategories[0]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultSecondaryNodeMetricCategories[1]
+                    }
+                  ]
+                },
+                others: [
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'duration',
+                      aggregation: MetricAggregationType.P50,
+                      'display-name': 'P50 Latency'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'errorCount',
+                      aggregation: MetricAggregationType.Sum,
+                      'display-name': 'Errors'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'errorCount',
+                      aggregation: MetricAggregationType.AvgrateSecond,
+                      'display-name': 'Errors/s'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'numCalls',
+                      aggregation: MetricAggregationType.Sum,
+                      'display-name': 'Calls'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'numCalls',
+                      aggregation: MetricAggregationType.AvgrateSecond,
+                      'display-name': 'Calls/s'
+                    }
+                  }
+                ]
+              },
+              'edge-metrics': {
+                type: 'topology-metrics',
+                primary: {
+                  type: 'topology-metric-with-category',
+                  specification: {
+                    type: 'percentile-latency-metric-aggregation',
+                    'display-name': 'P99 Latency'
+                  },
+                  categories: [
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryEdgeMetricCategories[0]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryEdgeMetricCategories[1]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryEdgeMetricCategories[2]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryEdgeMetricCategories[3]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultPrimaryEdgeMetricCategories[4]
+                    }
+                  ]
+                },
+                secondary: {
+                  type: 'topology-metric-with-category',
+                  specification: {
+                    type: 'error-percentage-metric-aggregation',
+                    aggregation: MetricAggregationType.Average,
+                    'display-name': 'Error %'
+                  },
+                  categories: [
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultSecondaryEdgeMetricCategories[0]
+                    },
+                    {
+                      type: 'topology-metric-category',
+                      ...defaultSecondaryEdgeMetricCategories[1]
+                    }
+                  ]
+                },
+                others: [
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'duration',
+                      aggregation: MetricAggregationType.P50,
+                      'display-name': 'P50 Latency'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'errorCount',
+                      aggregation: MetricAggregationType.Sum,
+                      'display-name': 'Errors'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'errorCount',
+                      aggregation: MetricAggregationType.AvgrateSecond,
+                      'display-name': 'Errors/s'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'numCalls',
+                      aggregation: MetricAggregationType.Sum,
+                      'display-name': 'Calls'
+                    }
+                  },
+                  {
+                    type: 'topology-metric-with-category',
+                    specification: {
+                      type: 'metric-aggregation',
+                      metric: 'numCalls',
+                      aggregation: MetricAggregationType.AvgrateSecond,
+                      'display-name': 'Calls/s'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
       }
     ]
   }

--- a/projects/observability/src/pages/apis/service-detail/overview/service-overview.dashboard.ts
+++ b/projects/observability/src/pages/apis/service-detail/overview/service-overview.dashboard.ts
@@ -28,7 +28,7 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
         },
         {
           type: 'dimension-model',
-          dimension: 0.3,
+          dimension: 0.2,
           unit: 'FR',
           'min-dimension': 345
         }
@@ -87,6 +87,11 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
             },
             {
               type: 'dimension-model',
+              dimension: 88,
+              unit: 'PX'
+            },
+            {
+              type: 'dimension-model',
               dimension: 320,
               unit: 'PX'
             },
@@ -100,28 +105,21 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
             {
               type: 'cell-span-model',
               'col-start': 0,
-              'col-end': 1,
-              'row-start': 0,
-              'row-end': 1
-            },
-            {
-              type: 'cell-span-model',
-              'col-start': 1,
               'col-end': 2,
               'row-start': 0,
               'row-end': 1
             },
             {
               type: 'cell-span-model',
-              'col-start': 2,
-              'col-end': 3,
-              'row-start': 0,
-              'row-end': 1
+              'col-start': 0,
+              'col-end': 1,
+              'row-start': 1,
+              'row-end': 2
             },
             {
               type: 'cell-span-model',
-              'col-start': 0,
-              'col-end': 3,
+              'col-start': 1,
+              'col-end': 2,
               'row-start': 1,
               'row-end': 2
             },
@@ -131,6 +129,13 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
               'col-end': 3,
               'row-start': 2,
               'row-end': 3
+            },
+            {
+              type: 'cell-span-model',
+              'col-start': 0,
+              'col-end': 3,
+              'row-start': 3,
+              'row-end': 4
             }
           ]
         },
@@ -153,6 +158,19 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
                     type: 'metric-aggregation',
                     metric: 'duration',
                     aggregation: MetricAggregationType.P99
+                  }
+                }
+              },
+              {
+                type: 'metric-display-widget',
+                title: 'P95 Latency',
+                subscript: 'ms',
+                data: {
+                  type: 'entity-metric-aggregation-data-source',
+                  metric: {
+                    type: 'metric-aggregation',
+                    metric: 'duration',
+                    aggregation: MetricAggregationType.P95
                   }
                 }
               },

--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.test.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.test.ts
@@ -45,6 +45,12 @@ describe('Explorer dashboard builder', () => {
             'selection-handler': {
               type: 'cartesian-explorer-selection-handler',
               'show-context-menu': false
+            },
+            'show-y-axis': true,
+            'y-axis': {
+              type: 'cartesian-axis',
+              'show-grid-lines': true,
+              'min-upper-limit': 25
             }
           },
           onReady: expect.any(Function)

--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -66,6 +66,12 @@ export class ExplorerDashboardBuilder {
         'selection-handler': {
           type: 'cartesian-explorer-selection-handler',
           'show-context-menu': false
+        },
+        'show-y-axis': true,
+        'y-axis': {
+          type: 'cartesian-axis',
+          'show-grid-lines': true,
+          'min-upper-limit': 25
         }
       },
       onReady: dashboard => {

--- a/src/app/home/home.dashboard.ts
+++ b/src/app/home/home.dashboard.ts
@@ -84,7 +84,7 @@ export const homeDashboard: DashboardDefaultConfiguration = {
         {
           type: 'cell-span-model',
           'col-start': 0,
-          'col-end': 1,
+          'col-end': 2,
           'row-start': 1,
           'row-end': 2
         },


### PR DESCRIPTION
- Added Radar Chart to API Endpoints.
- Adds `P95` along with `P99` and `P50`.
- Edited all the screens so text overlap and truncation no longer exists (except for Explorer tags, which occurs from Backend)
- Added `Y Axis` label on Explorer screen.

*HomePage*
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/56739130/180394324-bf50a004-f6e4-48b4-96f5-278379db6756.png">


*Explorer*
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/56739130/180394375-ca97c3b0-4285-4c69-b154-6149532b9e43.png">


*API Endpoints*
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/56739130/180394586-9c63cac7-b8af-4ede-ac98-1296d42b8203.png">

*Services Overview*
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/56739130/180394645-9edd17b3-7084-4c96-b835-78536fb729c1.png">


Note: **Will raise a separate PR for Custom date fix**