### PR TITLE
Enhance the custom date UI

### DIFF
--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -33,7 +33,7 @@ export class RudderStackTelemetry implements UserTelemetryProvider<RudderStackCo
       },
       error => {
         // tslint:disable-next-line: no-console
-        console.error('something went wrong in identify ', error);
+        console.error('something went wrong in identify method', error);
       }
     );
   }

--- a/projects/components/src/datetime-picker/datetime-picker.component.scss
+++ b/projects/components/src/datetime-picker/datetime-picker.component.scss
@@ -17,16 +17,8 @@
 
   .date-selector {
     height: 32px;
-    width: 160px;
     border: 1px solid $gray-1;
     margin-right: 12px;
-  }
-
-  .time-selector {
-    height: 32px;
-    border: 1px solid $gray-1;
-    background: $gray-1;
-    border-radius: 4px;
   }
 }
 

--- a/projects/components/src/datetime-picker/datetime-picker.component.test.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.test.ts
@@ -1,16 +1,16 @@
-import { Time } from '@hypertrace/common';
-import { DatetimePickerComponent, InputComponent, LabelComponent, TimePickerComponent } from '@hypertrace/components';
+import { DatetimePickerComponent, InputComponent, LabelComponent } from '@hypertrace/components';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 
 describe('Date Time Picker Component', () => {
   let spectator: SpectatorHost<DatetimePickerComponent>;
   const onDateChangeSpy = jest.fn();
-  const initDate = new Date();
+  const INIT_DATE_STRING = '2022-01-01T12:00';
+  const initDate = new Date(INIT_DATE_STRING);
   const createHost = createHostFactory({
     component: DatetimePickerComponent,
     shallow: true,
-    declarations: [MockComponent(LabelComponent), MockComponent(InputComponent), MockComponent(TimePickerComponent)]
+    declarations: [MockComponent(LabelComponent), MockComponent(InputComponent)]
   });
 
   beforeEach(() => {
@@ -28,55 +28,21 @@ describe('Date Time Picker Component', () => {
 
   test('should render all elements correctly', () => {
     expect(spectator.query(LabelComponent)).not.toExist();
-    expect(spectator.query(InputComponent)?.value).toEqual(initDate.toISOString().slice(0, 10));
-
-    const timePicker = spectator.query(TimePickerComponent);
-    expect(timePicker).toExist();
-    expect(timePicker?.time).toEqual(new Time(initDate.getHours(), initDate.getMinutes()));
-    expect(timePicker?.showTimeTriggerIcon).toEqual(false);
-
-    spectator.triggerEventHandler(InputComponent, 'valueChange', '2020-10-10');
+    expect(spectator.query(InputComponent)?.value).toEqual(INIT_DATE_STRING);
+    const NEW_DATETIME_STRING = '2022-02-02T13:00';
+    spectator.triggerEventHandler(InputComponent, 'valueChange', NEW_DATETIME_STRING);
     expect(onDateChangeSpy).toHaveBeenCalledWith(spectator.component.date);
-
-    const changedTime = new Time(10);
-    spectator.triggerEventHandler(TimePickerComponent, 'timeChange', changedTime);
-    const changedDate = new Date(spectator.component.date!.valueOf());
-    changedDate.setHours(changedTime.hours);
-    changedDate.setMinutes(changedTime.minutes);
-    expect(onDateChangeSpy).toHaveBeenCalledWith(changedDate);
   });
 
   test('date should not get effected when time is updated', () => {
-    const validationSet = [
-      {
-        date: new Date('2020-10-10'),
-        time: new Time(18, 10, 0, 0, true),
-        expected: '2020-10-10'
-      },
-      {
-        date: new Date('2020-1-1'),
-        time: new Time(0, 30, 0, 0, true),
-        expected: '2020-01-01'
-      },
-      {
-        date: new Date('2020-1-1'),
-        time: new Time(23, 59, 0, 0, true),
-        expected: '2020-01-01'
-      },
-      {
-        date: new Date('2020-1-1'),
-        time: new Time(0, 0, 0, 0, true),
-        expected: '2020-01-01'
-      }
-    ];
+    const validationSet = ['2020-10-10T12:18', '2020-01-01T00:30', '2020-01-01T23:59', '2020-01-01T00:00'];
 
-    validationSet.forEach(({ date, time, expected }) => {
-      spectator.setHostInput({ date: date });
-      spectator.triggerEventHandler(TimePickerComponent, 'timeChange', time);
-      const changedDate = new Date(date.valueOf());
-      changedDate.setHours(time.hours, time.minutes);
+    validationSet.forEach(dateTimeString => {
+      spectator.setHostInput({ date: new Date(INIT_DATE_STRING) });
+      spectator.triggerEventHandler(InputComponent, 'valueChange', dateTimeString);
+      const changedDate = new Date(dateTimeString);
       expect(onDateChangeSpy).toHaveBeenCalledWith(changedDate);
-      expect(spectator.component.getInputDate()).toEqual(expected);
+      expect(spectator.component.getInputDate()).toEqual(dateTimeString);
     });
   });
 });

--- a/projects/components/src/datetime-picker/datetime-picker.component.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Time } from '@hypertrace/common';
 import { InputAppearance } from '../input/input-appearance';
 
 @Component({
@@ -56,7 +55,7 @@ export class DatetimePickerComponent implements ControlValueAccessor {
   @Output()
   public readonly dateChange: EventEmitter<Date> = new EventEmitter();
 
-  public inputType = this.showDateOnly ? 'date' : 'datetime-local';
+  public inputType: string = this.showDateOnly ? 'date' : 'datetime-local';
   public dateTimeString?: string;
 
   private propagateControlValueChange?: (value?: Date) => void;
@@ -88,7 +87,6 @@ export class DatetimePickerComponent implements ControlValueAccessor {
   }
 
   public onDateChange(date: string): void {
-    debugger;
     if (date === '') {
       return;
     }
@@ -111,7 +109,7 @@ ${this.leftPadByZero(paramDate.getHours())}:${this.leftPadByZero(paramDate.getMi
     return undefined;
   }
 
-  public formatDateObjectToISOString(dateParam: Date) {
+  public formatDateObjectToISOString(dateParam: Date): string {
     return dateParam.toISOString().slice(0, 10);
   }
 
@@ -120,10 +118,10 @@ ${this.leftPadByZero(paramDate.getHours())}:${this.leftPadByZero(paramDate.getMi
   }
 
   public leftPadByZero(param: number): string {
-    return ('0' + param).slice(-2);
+    return `0${param}`.slice(-2);
   }
 
-  public leftPadYear(year: number) {
-    return ('000' + year).slice(-4);
+  public leftPadYear(year: number): string {
+    return `000${year}`.slice(-4);
   }
 }

--- a/projects/components/src/datetime-picker/datetime-picker.component.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Time, TypedSimpleChanges } from '@hypertrace/common';
+import { Time } from '@hypertrace/common';
 import { InputAppearance } from '../input/input-appearance';
 
 @Component({
@@ -20,28 +20,21 @@ import { InputAppearance } from '../input/input-appearance';
 
       <div class="datetime-controls">
         <ht-input
-          type="date"
+          [type]="this.inputType"
           class="date-selector"
           required="true"
           appearance="${InputAppearance.Border}"
           [value]="this.getInputDate()"
+          [min]="this.formatDateToDateTimeLocal(this.min)"
+          [max]="this.formatDateToDateTimeLocal(this.max)"
           (valueChange)="this.onDateChange($event)"
         >
         </ht-input>
-
-        <ng-container *ngIf="!this.showDateOnly"
-          ><ht-time-picker
-            class="time-selector"
-            [time]="this.time"
-            [showTimeTriggerIcon]="this.showTimeTriggerIcon"
-            (timeChange)="this.onTimeChange($event)"
-          ></ht-time-picker
-        ></ng-container>
       </div>
     </div>
   `
 })
-export class DatetimePickerComponent implements ControlValueAccessor, OnChanges {
+export class DatetimePickerComponent implements ControlValueAccessor {
   @Input()
   public label?: string;
 
@@ -52,24 +45,29 @@ export class DatetimePickerComponent implements ControlValueAccessor, OnChanges 
   public date?: Date = new Date();
 
   @Input()
+  public min?: Date;
+
+  @Input()
+  public max?: Date;
+
+  @Input()
   public showDateOnly: boolean = false;
 
   @Output()
   public readonly dateChange: EventEmitter<Date> = new EventEmitter();
 
-  public time?: Time;
-
-  public ngOnChanges(changes: TypedSimpleChanges<this>): void {
-    if (changes.date) {
-      this.time = this.date !== undefined ? this.getInputTime(this.date) : undefined;
-    }
-  }
+  public inputType = this.showDateOnly ? 'date' : 'datetime-local';
+  public dateTimeString?: string;
 
   private propagateControlValueChange?: (value?: Date) => void;
   private propagateControlValueChangeOnTouch?: (value?: Date) => void;
 
   public getInputDate(): string {
-    return this.date?.toISOString().slice(0, 10) ?? '';
+    if (this.showDateOnly) {
+      return this.formatDateObjectToISOString(this.date!);
+    }
+
+    return this.formatDateToDateTimeLocal(this.date!)!;
   }
 
   public writeValue(value?: Date): void {
@@ -89,28 +87,43 @@ export class DatetimePickerComponent implements ControlValueAccessor, OnChanges 
     this.propagateControlValueChangeOnTouch?.(value);
   }
 
-  private getInputTime(date: Date): Time {
-    return new Time(date.getHours(), date.getMinutes());
-  }
-
   public onDateChange(date: string): void {
+    debugger;
     if (date === '') {
       return;
     }
 
-    // The html input uses the format YYYY-MM-DD
-    const d: Date = new Date(this.date!);
-    const yearMonthDay = date.split('-');
-    d.setFullYear(Number(yearMonthDay[0]), Number(yearMonthDay[1]) - 1, Number(yearMonthDay[2]));
+    const d: Date = this.formatDateTimeLocalToDate(date);
+    d.setFullYear(d.getFullYear(), d.getMonth(), d.getDate());
     this.date = d;
     this.dateChange.emit(d);
     this.propagateValueChangeToFormControl(d);
   }
 
-  public onTimeChange(time: Time): void {
-    this.time = time;
-    this.date?.setUTCHours(time.hours, time.minutes, time.seconds, time.milliseconds);
-    this.dateChange.emit(this.date);
-    this.propagateValueChangeToFormControl(this.date);
+  public formatDateToDateTimeLocal(paramDate: Date | undefined): string | undefined {
+    if (paramDate !== undefined) {
+      return `${this.leftPadYear(paramDate.getFullYear())}-${this.leftPadByZero(
+        paramDate.getMonth() + 1
+      )}-${this.leftPadByZero(paramDate.getDate())}T\
+${this.leftPadByZero(paramDate.getHours())}:${this.leftPadByZero(paramDate.getMinutes())}`;
+    }
+
+    return undefined;
+  }
+
+  public formatDateObjectToISOString(dateParam: Date) {
+    return dateParam.toISOString().slice(0, 10);
+  }
+
+  public formatDateTimeLocalToDate(dateTimeString: string): Date {
+    return new Date(dateTimeString);
+  }
+
+  public leftPadByZero(param: number): string {
+    return ('0' + param).slice(-2);
+  }
+
+  public leftPadYear(year: number) {
+    return ('000' + year).slice(-4);
   }
 }

--- a/projects/components/src/input/input.component.ts
+++ b/projects/components/src/input/input.component.ts
@@ -31,6 +31,8 @@ import { InputAppearance } from './input-appearance';
         [disabled]="this.disabled"
         [placeholder]="this.placeholderValue"
         [ngModel]="this.value"
+        [min]="this.min"
+        [max]="this.max"
         (ngModelChange)="this.onValueChange($event)"
       />
     </mat-form-field>
@@ -42,6 +44,12 @@ export class InputComponent<T extends string | number> implements ControlValueAc
 
   @Input()
   public value?: T;
+
+  @Input()
+  public min?: T;
+
+  @Input()
+  public max?: T;
 
   @Input()
   public type?: string;

--- a/projects/components/src/time-range/custom-time-range-selection.component.ts
+++ b/projects/components/src/time-range/custom-time-range-selection.component.ts
@@ -18,7 +18,7 @@ import { ButtonRole } from '../button/button';
           <div style="width: 24px;"></div>
 
           <!-- To Date & Time -->
-          <ht-datetime-picker label="To" [(date)]="this.to"></ht-datetime-picker>
+          <ht-datetime-picker label="To" [(date)]="this.to" [min]="this.from"></ht-datetime-picker>
         </div>
 
         <div class="divider"></div>


### PR DESCRIPTION
Preview of the feature can be seen in this [slack message](https://razorpay.slack.com/archives/CU5GKS8MQ/p1658925623102809)
- Add `min` and `max` attribute support to `ht-input`.
- Use `datetime-local` instead of `date` and remove `TimePickerComponent` for the `CustomTimeRange`.
- Adds some date related utils to handle the date formats.
  - `datetime-local` expects input in format `YYYY-mm-ddTHH:mm` and also outputs in the same format.
  - Have used `leftPad` methods to handle edge cases for all the fields mentioned above.
- Update the test cases for the new date time picker. 