### PR TITLE
Added properties related to analytics in config rather than secret.

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -5,6 +5,10 @@ server {
         proxy_pass http://graphql-service:23431/graphql;
       }
 
+      location /user-preferences/ {
+        proxy_pass http://hypertrace-user-service:9400/;
+      }
+
       location = /user-info {
         default_type application/json;
         return 200 '{"email":"$http_x_forwarded_email", "name": "$http_x_forwarded_user"}';

--- a/copy-secrets.sh
+++ b/copy-secrets.sh
@@ -1,14 +1,3 @@
 FILENAME="/usr/share/nginx/html/secrets.js"
 touch $FILENAME
-if [ -z $ENABLE_ANALYTICS ]
-then
-   ENABLE_ANALYTICS="false"
-fi
-echo "window.ENABLE_ANALYTICS = \"$ENABLE_ANALYTICS\";" > $FILENAME
-if [ "$ENABLE_ANALYTICS" = "true" ]
-then
-    echo "window.RUDDERSTACK_HT_WRITE_KEY = \"$RUDDERSTACK_HT_WRITE_KEY\";" >> $FILENAME
-    echo "window.RUDDERSTACK_HT_DATAPLANE_URL = \"$RUDDERSTACK_HT_DATAPLANE_URL\";" >> $FILENAME
-else 
-    echo "Analytics is disabled"
-fi
+echo "window.RUDDERSTACK_HT_WRITE_KEY = \"$RUDDERSTACK_HT_WRITE_KEY\";" >> $FILENAME

--- a/copy-secrets.sh
+++ b/copy-secrets.sh
@@ -1,3 +1,3 @@
 FILENAME="/usr/share/nginx/html/secrets.js"
 touch $FILENAME
-echo "window.RUDDERSTACK_HT_WRITE_KEY = \"$RUDDERSTACK_HT_WRITE_KEY\";" >> $FILENAME
+echo "window.RUDDERSTACK_HT_WRITE_KEY = \"$RUDDERSTACK_HT_WRITE_KEY\";" > $FILENAME

--- a/projects/assets-library/assets/json/config.json
+++ b/projects/assets-library/assets/json/config.json
@@ -4,5 +4,9 @@
     "ui.custom-dashboards": true
   },
   "urlConfig": {},
-  "dashboardConfig": {}
+  "dashboardConfig": {},
+  "analyticsConfig": {
+    "enabled": false,
+    "rudderstack_dataplane_url": ""
+  }
 }

--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -5,6 +5,9 @@ import { HttpClient } from '@angular/common/http';
 import { apiObject, identify, load, page, track } from 'rudder-sdk-js';
 import { TelemetryProviderConfig, UserTelemetryProvider, UserTraits } from '../../telemetry';
 
+// tslint:disable-next-line: import-blacklist
+import type { CustomWindow } from '../../../../../../src/app/root.module';
+
 export interface RudderStackConfig extends TelemetryProviderConfig {
   writeKey: string;
 }
@@ -15,7 +18,7 @@ export class RudderStackTelemetry implements UserTelemetryProvider<RudderStackCo
 
   public initialize(config: RudderStackConfig): void {
     try {
-      load(config.writeKey, config.orgId, { configUrl: config.orgId });
+      load(config.writeKey, (window as CustomWindow)?.analyticsConfig.rudderstack_dataplane_url);
     } catch (error) {
       /**
        * Fail silently

--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -25,10 +25,10 @@ declare const window: CustomWindow;
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
-    RootRoutingModule,
-    ConfigModule,
-    NavigationModule,
     HttpClientModule,
+    ConfigModule,
+    RootRoutingModule,
+    NavigationModule,
     ApplicationFrameModule,
     ObservabilityDashboardModule,
     UserTelemetryModule.forRoot([

--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -12,9 +12,11 @@ import { NavigationModule } from './shared/navigation/navigation.module';
 
 export type CustomWindow = Window &
   typeof globalThis & {
-    RUDDERSTACK_HT_DATAPLANE_URL?: string;
-    RUDDERSTACK_HT_WRITE_KEY?: string;
-    ENABLE_ANALYTICS?: 'true' | 'false';
+    analyticsConfig: {
+      enabled: boolean;
+      rudderstack_dataplane_url: string;
+    };
+    RUDDERSTACK_HT_WRITE_KEY: string;
   };
 
 declare const window: CustomWindow;
@@ -36,7 +38,7 @@ declare const window: CustomWindow;
         enableEventTracking: true,
         enablePageTracking: true,
         initConfig: {
-          orgId: window.RUDDERSTACK_HT_DATAPLANE_URL,
+          orgId: window.analyticsConfig?.rudderstack_dataplane_url,
           writeKey: window.RUDDERSTACK_HT_WRITE_KEY
         }
       }

--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -25,10 +25,10 @@ declare const window: CustomWindow;
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
-    HttpClientModule,
-    ConfigModule,
     RootRoutingModule,
+    ConfigModule,
     NavigationModule,
+    HttpClientModule,
     ApplicationFrameModule,
     ObservabilityDashboardModule,
     UserTelemetryModule.forRoot([
@@ -38,7 +38,6 @@ declare const window: CustomWindow;
         enableEventTracking: true,
         enablePageTracking: true,
         initConfig: {
-          orgId: window.analyticsConfig?.rudderstack_dataplane_url,
           writeKey: window.RUDDERSTACK_HT_WRITE_KEY
         }
       }

--- a/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
+++ b/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
@@ -35,8 +35,6 @@ export class DynamicConfigurationService {
   }
   public setupAnalyticsConfig(): void {
     (window as CustomWindow).analyticsConfig = this.config?.analyticsConfig;
-    // tslint:disable-next-line: no-console
-    console.log('analytics setup is done ', (window as CustomWindow).analyticsConfig.rudderstack_dataplane_url);
   }
 }
 

--- a/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
+++ b/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
@@ -13,11 +13,14 @@ export class DynamicConfigurationService {
       throw new Error('Config service already loaded');
     }
   }
-  public load(): void {
-    this.http.get<UiConfiguration>('/assets/json/config.json').subscribe((data: UiConfiguration) => {
+
+  public load(): Observable<UiConfiguration> {
+    return this.http.get<UiConfiguration>('/assets/json/config.json').pipe(tap((data: UiConfiguration) => {
       this.config = data;
-    });
+      this.setupAnalyticsConfig();
+    }))
   }
+
   public isConfigPresentForFeature(feature: string): boolean {
     return this.config?.featureFlags?.hasOwnProperty(feature);
   }

--- a/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
+++ b/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
@@ -36,7 +36,7 @@ export class DynamicConfigurationService {
   public setupAnalyticsConfig(): void {
     (window as CustomWindow).analyticsConfig = this.config?.analyticsConfig;
     // tslint:disable-next-line: no-console
-    console.log('analytics setup is done');
+    console.log('analytics setup is done ', (window as CustomWindow).analyticsConfig.rudderstack_dataplane_url);
   }
 }
 

--- a/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
+++ b/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
@@ -1,5 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, Optional, SkipSelf } from '@angular/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import type { CustomWindow } from '../../root.module';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -15,10 +19,12 @@ export class DynamicConfigurationService {
   }
 
   public load(): Observable<UiConfiguration> {
-    return this.http.get<UiConfiguration>('/assets/json/config.json').pipe(tap((data: UiConfiguration) => {
-      this.config = data;
-      this.setupAnalyticsConfig();
-    }))
+    return this.http.get<UiConfiguration>('/assets/json/config.json').pipe(
+      tap((data: UiConfiguration) => {
+        this.config = data;
+        this.setupAnalyticsConfig();
+      })
+    );
   }
 
   public isConfigPresentForFeature(feature: string): boolean {
@@ -27,13 +33,21 @@ export class DynamicConfigurationService {
   public getValueForFeature(feature: string): string | number | boolean {
     return this.config?.featureFlags?.[feature];
   }
+  public setupAnalyticsConfig(): void {
+    (window as CustomWindow).analyticsConfig = this.config?.analyticsConfig;
+  }
 }
 
 interface UiConfiguration {
   featureFlags: FlagsConfig;
   urlConfig: FlagsConfig;
   dashboardConfig: FlagsConfig;
+  analyticsConfig: AnalyticsConfig;
 }
 interface FlagsConfig {
   [key: string]: string | boolean | number;
+}
+interface AnalyticsConfig {
+  enabled: boolean;
+  rudderstack_dataplane_url: string;
 }

--- a/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
+++ b/src/app/shared/dynamic-configuration/dynamic-configuration.service.ts
@@ -35,6 +35,8 @@ export class DynamicConfigurationService {
   }
   public setupAnalyticsConfig(): void {
     (window as CustomWindow).analyticsConfig = this.config?.analyticsConfig;
+    // tslint:disable-next-line: no-console
+    console.log('analytics setup is done');
   }
 }
 

--- a/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
+++ b/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
@@ -12,7 +12,7 @@ export class UserTelemetryOrchestrationService {
   public constructor(private readonly userTelemetryService: UserTelemetryService) {}
 
   public initialize(): void {
-    if (window.ENABLE_ANALYTICS === 'true') {
+    if (window?.analyticsConfig?.enabled) {
       this.userTelemetryService.initialize();
 
       /**

--- a/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
+++ b/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
@@ -12,6 +12,8 @@ export class UserTelemetryOrchestrationService {
   public constructor(private readonly userTelemetryService: UserTelemetryService) {}
 
   public initialize(): void {
+    // tslint:disable-next-line: no-console
+    console.log('user tel orch init ', window?.analyticsConfig);
     if (window?.analyticsConfig?.enabled) {
       this.userTelemetryService.initialize();
 

--- a/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
+++ b/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
@@ -12,13 +12,6 @@ export class UserTelemetryOrchestrationService {
   public constructor(private readonly userTelemetryService: UserTelemetryService) {}
 
   public initialize(): void {
-    // tslint:disable-next-line: no-console
-    console.log(
-      'user tel orch init ',
-      window?.analyticsConfig?.enabled,
-      window?.analyticsConfig?.rudderstack_dataplane_url,
-      window.RUDDERSTACK_HT_WRITE_KEY
-    );
     if (window?.analyticsConfig?.enabled) {
       this.userTelemetryService.initialize();
 

--- a/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
+++ b/src/app/shared/telemetry/user-telemetry-orchestration.service.ts
@@ -13,7 +13,12 @@ export class UserTelemetryOrchestrationService {
 
   public initialize(): void {
     // tslint:disable-next-line: no-console
-    console.log('user tel orch init ', window?.analyticsConfig);
+    console.log(
+      'user tel orch init ',
+      window?.analyticsConfig?.enabled,
+      window?.analyticsConfig?.rudderstack_dataplane_url,
+      window.RUDDERSTACK_HT_WRITE_KEY
+    );
     if (window?.analyticsConfig?.enabled) {
       this.userTelemetryService.initialize();
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -1,4 +1,4 @@
 // Replace the below values with respective write key and dataplane URL on local
 // Please be mindful while pushing changes in this file as it is served to the browser
 // Ensure that it doesn't have any secrets
-window.RUDDERSTACK_HT_WRITE_KEY = '2BpjcpXywwQujWTYRvcj5rpVwSb';
+window.RUDDERSTACK_HT_WRITE_KEY = 'RUDDERSTACK_HT_WRITE_KEY';

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -1,6 +1,4 @@
 // Replace the below values with respective write key and dataplane URL on local
 // Please be mindful while pushing changes in this file as it is served to the browser
 // Ensure that it doesn't have any secrets
-window.ENABLE_ANALYTICS = 'false'; // this will be string as the environment variables are string
-window.RUDDERSTACK_HT_WRITE_KEY = 'RUDDERSTACK_HT_WRITE_KEY';
-window.RUDDERSTACK_HT_DATAPLANE_URL = 'RUDDERSTACK_HT_DATAPLANE_URL';
+window.RUDDERSTACK_HT_WRITE_KEY = '2BpjcpXywwQujWTYRvcj5rpVwSb';


### PR DESCRIPTION
- Returning an observable in `load()` method for `DynamicConfigService` as it will be ensured that the config is loaded before anything else occurs.
- Updated `copy-secrets.sh` to only add the secret part.
- Updated `config.json` to be reflective of changes in `kube-manifests`.
- Loading analytics configuration post dynamic configuration is loaded.