### PR TITLE
fix: randomly loading ht-user when refreshing saved-queries page

### DIFF
--- a/projects/common/src/user-preference/user-preference.service.ts
+++ b/projects/common/src/user-preference/user-preference.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken } from '@angular/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { UserInfoService } from './../user/user-info.service';
 interface TokenOptions {
   uri: string;
@@ -12,6 +12,7 @@ export const USER_PREFERENCES_OPTIONS = new InjectionToken<TokenOptions>('USER_P
 })
 export class UserPreferenceService {
   public BASE_URL: string;
+  public hasLoaded: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   public constructor(
     private readonly http: HttpClient,
@@ -34,7 +35,13 @@ export class UserPreferenceService {
    * already. More details: https://razorpay.slack.com/archives/CU5GKS8MQ/p1659328334493179?thread_ts=1659310225.849849&cid=CU5GKS8MQ
    */
   public addUser(): void {
-    this.userInfoService.load().subscribe(() => this.get('/v1/user/add').subscribe());
+    this.userInfoService.load().subscribe(() =>
+      this.get<{ success: boolean }>('/v1/user/add').subscribe(({ success }) => {
+        if (success) {
+          this.hasLoaded.next(true);
+        }
+      })
+    );
   }
 
   public get<T>(endPoint: string, params?: HttpParams): Observable<T> {

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.ts
@@ -57,17 +57,17 @@ export class SavedQueriesComponent implements OnInit {
     private readonly explorerService: ExplorerService,
     private readonly subscriptionLifecycle: SubscriptionLifecycle,
     private readonly savedQueriesService: SavedQueriesService
-  ) {
+  ) {}
+
+  public ngOnInit(): void {
+    // Todo: Remove this after some time. See method definition for details.
+    this.savedQueriesService.moveOldQueries();
+
     this.subscriptionLifecycle.add(
       this.savedQueriesService.getAllQueries().subscribe((queries: SavedQueryPayload[]) => {
         this.savedQueriesSubject.next(queries);
       })
     );
-  }
-
-  public ngOnInit(): void {
-    // Todo: Remove this after some time. See method definition for details.
-    this.savedQueriesService.moveOldQueries();
   }
 
   public getExplorerNavigationParams$(query: SavedQuery): Observable<NavigationParams> {

--- a/projects/observability/src/pages/saved-queries/saved-queries.component.ts
+++ b/projects/observability/src/pages/saved-queries/saved-queries.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { IconType } from '@hypertrace/assets-library';
-import { NavigationParams, SubscriptionLifecycle } from '@hypertrace/common';
+import { NavigationParams, SubscriptionLifecycle, UserPreferenceService } from '@hypertrace/common';
 import { DrilldownFilter, ExplorerService } from '../explorer/explorer-service';
 import { SavedQueriesService, SavedQuery, SavedQueryPayload } from './saved-queries.service';
 
@@ -56,7 +56,8 @@ export class SavedQueriesComponent implements OnInit {
   public constructor(
     private readonly explorerService: ExplorerService,
     private readonly subscriptionLifecycle: SubscriptionLifecycle,
-    private readonly savedQueriesService: SavedQueriesService
+    private readonly savedQueriesService: SavedQueriesService,
+    private readonly userPreferenceService: UserPreferenceService
   ) {}
 
   public ngOnInit(): void {
@@ -64,8 +65,14 @@ export class SavedQueriesComponent implements OnInit {
     this.savedQueriesService.moveOldQueries();
 
     this.subscriptionLifecycle.add(
-      this.savedQueriesService.getAllQueries().subscribe((queries: SavedQueryPayload[]) => {
-        this.savedQueriesSubject.next(queries);
+      this.userPreferenceService.hasLoaded.subscribe(hasLoaded => {
+        if (hasLoaded) {
+          this.subscriptionLifecycle.add(
+            this.savedQueriesService.getAllQueries().subscribe((queries: SavedQueryPayload[]) => {
+              this.savedQueriesSubject.next(queries);
+            })
+          );
+        }
       })
     );
   }


### PR DESCRIPTION
## Description

[Stage Environment][1] | [Discussion][2]

<p align="center">
  <img src="https://preview.redd.it/x4xsrmg4bad91.jpg?auto=webp&s=03cdce6379ce5608e431290eb7082ef6c33a01cd" width="320rem" />
</p>

**Bug:** If the user is on the saved-queries page and pressed refresh, sometimes the queries of the dummy ht-user get loaded. This is because the `/query/all` in the constructor of SavedQueriesComponent was getting triggered before the `/user-info` endpoint triggered by `APP_INITIALIZER` finished loading.

<p align="center">
<img width="433" alt="Screenshot 2022-08-12 at 12 49 27 PM" src="https://user-images.githubusercontent.com/29686866/184322973-cb5023f5-0157-4e81-8855-ea9dcb9fb0f5.png">
</p>

**Fix:** Added a BehaviorSubject to UserPreferenceService that indicates the loading status of the `addUser()` method. Now the SavedQueriesComponent only initiates the `/query/all` API once this method has finished loading.

### Testing
- [x] Tested on stage environment

### Checklist:
- [x] My changes generate no new warnings

[1]: https://razorpay.slack.com/archives/C03A6MZF5U4/p1660287287935069
[2]: https://razorpay.slack.com/archives/C03A6MZF5U4/p1660287287935069