### PR TITLE
Fix/build action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,8 +2,8 @@ name: build-and-test
 on:
   pull_request:
   push:
-    branches_ingore:
-      - 'main'
+    branches:
+      - 'rzp_main'
 jobs:
   npm-install-if-needed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,8 +2,8 @@ name: build-and-test
 on:
   pull_request:
   push:
-    branches:
-      - '!main'
+    branches_ingore:
+      - 'main'
 jobs:
   npm-install-if-needed:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- Before this, the `build-and-test.yml` action wasn't triggered when PR was merged to `rzp_main`.
- For PRs, the tests are triggered by the `pull_request` option, so the branches do not need anything extra.
- This PR fixes the same as we now have `rzp_main` as the branch for push.

Refer to [this](https://github.com/razorpay/hypertrace-ui/actions?query=event%3Apush) to understand the cause of actions.