### PR TITLE
Deployment Markers - Set up tab, routes and feature flag integration

### DIFF
--- a/projects/assets-library/assets/json/config.json
+++ b/projects/assets-library/assets/json/config.json
@@ -1,11 +1,12 @@
 {
   "featureFlags": {
     "ui.saved-queries": true,
-    "ui.custom-dashboards": true
+    "ui.custom-dashboards": true,
+    "ui.page-time-range": false,
+    "ui.instrumentation-quality": false,
+    "ui.deployment-markers": true
   },
-  "urlConfig": {
-    "user_preference": "https://hus.concierge.stage.razorpay.in"
-  },
+  "urlConfig": {},
   "dashboardConfig": {},
   "analyticsConfig": {
     "enabled": false,

--- a/projects/common/src/constants/application-constants.ts
+++ b/projects/common/src/constants/application-constants.ts
@@ -2,5 +2,6 @@ export const enum ApplicationFeature {
   PageTimeRange = 'ui.page-time-range',
   SavedQueries = 'ui.saved-queries',
   CustomDashboards = 'ui.custom-dashboards',
-  InstrumentationQuality = 'ui.instrumentation-quality'
+  InstrumentationQuality = 'ui.instrumentation-quality',
+  DeploymentMarkers = 'ui.deployment-markers'
 }

--- a/projects/components/src/breadcrumbs/breadcrumbs.service.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.service.test.ts
@@ -1,5 +1,6 @@
 import { IconType } from '@hypertrace/assets-library';
 import { Breadcrumb, HtRouteData, NavigationService } from '@hypertrace/common';
+import { ObservabilityIconType } from '@hypertrace/observability';
 import { runFakeRxjs } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
 import { NEVER, Observable, of, throwError } from 'rxjs';
@@ -108,6 +109,45 @@ describe('BreadcrumbsService', () => {
 
     spectator.service.breadcrumbs$.subscribe();
     expect(spectator.inject(NavigationService).navigateToErrorPage).toHaveBeenCalled();
+  });
+
+  test('Returns the last string in the breadcrumb path when getLastBreadCrumbString is called', () => {
+    const spectator = createService({
+      providers: [
+        mockProvider(NavigationService, {
+          getCurrentActivatedRoute: () => ({
+            snapshot: buildMockRoute([
+              {
+                urlSegments: ['services'],
+                breadcrumb: {
+                  label: 'services'
+                }
+              },
+              {
+                urlSegments: ['service'],
+                breadcrumb: {
+                  icon: ObservabilityIconType.Service,
+                  label: 'service'
+                }
+              },
+              {
+                urlSegments: ['1234-1234-1234'],
+                breadcrumb: {
+                  label: 'Service name'
+                }
+              }
+            ])
+          }),
+          navigation$: NEVER
+        })
+      ]
+    });
+
+    runFakeRxjs(({ expectObservable }) => {
+      expectObservable(spectator.service.getLastBreadCrumbString()).toBe('x', {
+        x: 'Service name'
+      });
+    });
   });
 });
 

--- a/projects/components/src/breadcrumbs/breadcrumbs.service.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.service.ts
@@ -69,9 +69,7 @@ export class BreadcrumbsService<T extends Breadcrumb = Breadcrumb> {
 
   public getLastBreadCrumbString(): Observable<string> {
     return this.breadcrumbs$.pipe(
-      map(breadCrumbs => {
-        return breadCrumbs.length > 0 ? breadCrumbs[breadCrumbs.length - 1]?.label ?? '' : '';
-      })
+      map(breadCrumbs => (breadCrumbs.length > 0 ? breadCrumbs[breadCrumbs.length - 1]?.label ?? '' : ''))
     );
   }
 

--- a/projects/components/src/breadcrumbs/breadcrumbs.service.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.service.ts
@@ -67,6 +67,14 @@ export class BreadcrumbsService<T extends Breadcrumb = Breadcrumb> {
     return of(activatedRouteSnapshot.data.breadcrumb);
   }
 
+  public getLastBreadCrumbString(): Observable<string> {
+    return this.breadcrumbs$.pipe(
+      map(breadCrumbs => {
+        return breadCrumbs.length > 0 ? breadCrumbs[breadCrumbs.length - 1]?.label ?? '' : '';
+      })
+    );
+  }
+
   public getPath(activatedRouteSnapshot: ActivatedRouteSnapshot): string[] {
     return activatedRouteSnapshot.pathFromRoot
       .flatMap(routeSnapshot => routeSnapshot.url)

--- a/projects/components/src/tabs/navigable/navigable-tab.ts
+++ b/projects/components/src/tabs/navigable/navigable-tab.ts
@@ -1,3 +1,5 @@
+import { ApplicationFeature } from '@hypertrace/common';
+
 export interface NavigableTab {
   path: string;
   label: string;
@@ -5,4 +7,5 @@ export interface NavigableTab {
   hidden?: boolean;
   features?: string[];
   replaceHistory?: boolean;
+  flagName?: ApplicationFeature;
 }

--- a/projects/observability/src/pages/apis/service-detail/deployments/service-deployments.component.scss
+++ b/projects/observability/src/pages/apis/service-detail/deployments/service-deployments.component.scss
@@ -1,0 +1,3 @@
+.service-deployments {
+  padding: 1rem 1.6rem;
+}

--- a/projects/observability/src/pages/apis/service-detail/deployments/service-deployments.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/deployments/service-deployments.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { BreadcrumbsService } from '@hypertrace/components';
+import { Observable } from 'rxjs';
+
+@Component({
+  styleUrls: ['./service-deployments.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <main class="service-deployments">
+      <p *ngIf="serviceName$ | async as serviceName; else loading">
+        Here is the list of your deployments in last 24 hours for {{ serviceName }}
+      </p>
+      <ng-template #loading> Loading stuff... </ng-template>
+    </main>
+  `
+})
+export class ServiceDeploymentsComponent {
+  public serviceName$: Observable<string> = this.breadcrumbsService.getLastBreadCrumbString();
+  public constructor(protected readonly breadcrumbsService: BreadcrumbsService) {}
+}

--- a/projects/observability/src/pages/apis/service-detail/deployments/service-deployments.module.ts
+++ b/projects/observability/src/pages/apis/service-detail/deployments/service-deployments.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ServiceDeploymentsComponent } from './service-deployments.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [ServiceDeploymentsComponent],
+  exports: [ServiceDeploymentsComponent]
+})
+export class ServiceDeploymentsModule {}

--- a/projects/observability/src/pages/apis/service-detail/service-detail.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.component.test.ts
@@ -63,7 +63,7 @@ describe('ServiceDetailComponent', () => {
     });
   });
 
-  test('Does not show tabs for disabled fetures', () => {
+  test('Does not show tabs for disabled features', () => {
     TestBed.configureTestingModule({
       declarations: [ServiceDetailComponent],
       imports: [RouterTestingModule, ServiceDetailModule],

--- a/projects/observability/src/pages/apis/service-detail/service-detail.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.component.test.ts
@@ -7,16 +7,63 @@ import { FeatureState, FeatureStateResolver } from '@hypertrace/common';
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { ENTITY_METADATA } from '@hypertrace/observability';
 
+import { NavigableTab } from '@hypertrace/components';
 // tslint:disable-next-line: import-blacklist
 import { entityMetadata } from '../../../../../../src/app/entity-metadata';
 import { ServiceDetailComponent } from './service-detail.component';
 import { ServiceDetailModule } from './service-detail.module';
 
+const featureFlaggedTabs: NavigableTab[] = [
+  {
+    path: 'instrumentation',
+    label: 'Instrumentation Quality'
+  },
+  {
+    path: 'deployments',
+    label: 'Deployments'
+  }
+];
+
 describe('ServiceDetailComponent', () => {
   let component: ServiceDetailComponent;
   let fixture: ComponentFixture<ServiceDetailComponent>;
 
-  beforeEach(() => {
+  test("Component exists and doesn't display Instrumentation tab when feature flag is disabled", () => {
+    TestBed.configureTestingModule({
+      declarations: [ServiceDetailComponent],
+      imports: [RouterTestingModule, ServiceDetailModule],
+      providers: [
+        {
+          provide: GRAPHQL_OPTIONS,
+          useValue: {
+            uri: '/graphql',
+            batchSize: 2
+          }
+        },
+        {
+          provide: ENTITY_METADATA,
+          useValue: entityMetadata
+        },
+        mockProvider(FeatureStateResolver, {
+          getFeatureState: () => of(FeatureState.Enabled)
+        })
+      ]
+    });
+    fixture = TestBed.createComponent(ServiceDetailComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    expect(component).toBeDefined();
+    featureFlaggedTabs.map(featureFlaggedTab => {
+      expect(component.tabs.find(tab => tab.path === featureFlaggedTab.path)).toHaveProperty(
+        'path',
+        featureFlaggedTab.path
+      );
+    });
+  });
+
+  test('Shows Deployments tab when it"s feature flag is enabled', () => {
     TestBed.configureTestingModule({
       declarations: [ServiceDetailComponent],
       imports: [RouterTestingModule, ServiceDetailModule],
@@ -41,13 +88,8 @@ describe('ServiceDetailComponent', () => {
     component = fixture.componentInstance;
 
     fixture.detectChanges();
-  });
-
-  test('should be created successfully', () => {
-    expect(component).toBeDefined();
-  });
-
-  test("doesn't display Instrumentation tab when feature flag is disabled", () => {
-    expect(component.tabs.find(tab => tab.path === 'instrumentation')).toBe(undefined);
+    featureFlaggedTabs.map(featureFlaggedTab => {
+      expect(component.tabs.find(tab => tab.path === featureFlaggedTab.path)).toBeUndefined();
+    });
   });
 });

--- a/projects/observability/src/pages/apis/service-detail/service-detail.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.component.test.ts
@@ -28,7 +28,7 @@ describe('ServiceDetailComponent', () => {
   let component: ServiceDetailComponent;
   let fixture: ComponentFixture<ServiceDetailComponent>;
 
-  test("Component exists and doesn't display Instrumentation tab when feature flag is disabled", () => {
+  test('Component exists and shows tabs for enabled features', () => {
     TestBed.configureTestingModule({
       declarations: [ServiceDetailComponent],
       imports: [RouterTestingModule, ServiceDetailModule],
@@ -63,7 +63,7 @@ describe('ServiceDetailComponent', () => {
     });
   });
 
-  test('Shows Deployments tab when it"s feature flag is enabled', () => {
+  test('Does not show tabs for disabled fetures', () => {
     TestBed.configureTestingModule({
       declarations: [ServiceDetailComponent],
       imports: [RouterTestingModule, ServiceDetailModule],

--- a/projects/observability/src/pages/apis/service-detail/service-detail.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.component.ts
@@ -66,6 +66,7 @@ export class ServiceDetailComponent {
           this.tabs.push(this.featureFlaggedTabs[index]);
         }
       });
+
       return this.tabs;
     })
   );

--- a/projects/observability/src/pages/apis/service-detail/service-detail.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.component.ts
@@ -1,6 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ApplicationFeature, FeatureState, FeatureStateResolver, SubscriptionLifecycle } from '@hypertrace/common';
+import {
+  ApplicationFeature,
+  FeatureState,
+  FeatureStateResolver,
+  forkJoinSafeEmpty,
+  SubscriptionLifecycle
+} from '@hypertrace/common';
 import { NavigableTab } from '@hypertrace/components';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
 import { ServiceDetailService } from './service-detail.service';
 
 @Component({
@@ -8,7 +17,7 @@ import { ServiceDetailService } from './service-detail.service';
   providers: [ServiceDetailService, SubscriptionLifecycle],
   template: `
     <div class="vertical-flex-layout">
-      <ht-page-header [tabs]="this.tabs"></ht-page-header>
+      <ht-page-header [tabs]="this.enabledTabs$ | async"></ht-page-header>
       <div class="scrollable-container">
         <router-outlet></router-outlet>
       </div>
@@ -35,18 +44,31 @@ export class ServiceDetailComponent {
     }
   ];
 
-  public constructor(private readonly featureStateResolver: FeatureStateResolver) {
-    /**
-     * TODO: Create a generic config to map tabs to feature flags if more tabs
-     * are to be added in the future: https://github.com/razorpay/hypertrace-ui/pull/80#issuecomment-1235141757
-     */
-    this.featureStateResolver.getFeatureState(ApplicationFeature.InstrumentationQuality).subscribe(
-      featureState =>
-        featureState === FeatureState.Enabled &&
-        this.tabs.push({
-          path: 'instrumentation',
-          label: 'Instrumentation Quality'
-        })
-    );
-  }
+  public readonly featureFlaggedTabs: NavigableTab[] = [
+    {
+      path: 'instrumentation',
+      label: 'Instrumentation Quality',
+      flagName: ApplicationFeature.InstrumentationQuality
+    },
+    {
+      path: 'deployments',
+      label: 'Deployments',
+      flagName: ApplicationFeature.DeploymentMarkers
+    }
+  ];
+
+  public enabledTabs$: Observable<NavigableTab[]> = forkJoinSafeEmpty(
+    this.featureFlaggedTabs.map(tab => this.featureStateResolver.getFeatureState(tab.flagName!))
+  ).pipe(
+    map(featureVals => {
+      featureVals.map((featureVal, index) => {
+        if (featureVal === FeatureState.Enabled) {
+          this.tabs.push(this.featureFlaggedTabs[index]);
+        }
+      });
+    }),
+    map(() => this.tabs)
+  );
+
+  public constructor(private readonly featureStateResolver: FeatureStateResolver) {}
 }

--- a/projects/observability/src/pages/apis/service-detail/service-detail.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.component.ts
@@ -66,8 +66,8 @@ export class ServiceDetailComponent {
           this.tabs.push(this.featureFlaggedTabs[index]);
         }
       });
-    }),
-    map(() => this.tabs)
+      return this.tabs;
+    })
   );
 
   public constructor(private readonly featureStateResolver: FeatureStateResolver) {}

--- a/projects/observability/src/pages/apis/service-detail/service-detail.module.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail.module.ts
@@ -5,6 +5,7 @@ import { NavigableTabModule, PageHeaderModule } from '@hypertrace/components';
 import { GraphQlModule } from '@hypertrace/graphql-client';
 import { EntityGraphQlQueryHandlerService } from '../../../shared/graphql/request/handlers/entities/query/entity/entity-graphql-query-handler.service';
 import { ServiceApisListModule } from './apis/service-apis-list.module';
+import { ServiceDeploymentsModule } from './deployments/service-deployments.module';
 import { ServiceInstrumentationModule } from './instrumentation/service-instrumentation.module';
 import { ServiceMetricsModule } from './metrics/service-metrics.module';
 import { ServiceOverviewModule } from './overview/service-overview.module';
@@ -24,6 +25,7 @@ import { ServiceTraceListModule } from './traces/service-trace-list.module';
     ServiceTraceListModule,
     ServiceMetricsModule,
     ServiceInstrumentationModule,
+    ServiceDeploymentsModule,
     PageHeaderModule
   ]
 })

--- a/projects/observability/src/public-api.ts
+++ b/projects/observability/src/public-api.ts
@@ -236,6 +236,7 @@ export * from './pages/apis/service-detail/service-detail.component';
 export * from './pages/apis/service-detail/service-detail.service';
 export * from './pages/apis/service-detail/service-detail-breadcrumb.resolver';
 export * from './pages/apis/service-detail/instrumentation/service-instrumentation.component';
+export * from './pages/apis/service-detail/deployments/service-deployments.component';
 export * from './pages/apis/service-detail/metrics/service-metrics.component';
 export * from './pages/apis/service-detail/overview/service-overview.component';
 export * from './pages/apis/service-detail/traces/service-trace-list.component';

--- a/src/app/routes/services/service-detail/service-detail-routing.module.ts
+++ b/src/app/routes/services/service-detail/service-detail-routing.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import {
   ServiceApisListComponent,
+  ServiceDeploymentsComponent,
   ServiceDetailComponent,
   ServiceDetailModule,
   ServiceInstrumentationComponent,
@@ -41,6 +42,10 @@ const ROUTE_CONFIG: HtRoute[] = [
       {
         path: 'instrumentation',
         component: ServiceInstrumentationComponent
+      },
+      {
+        path: 'deployments',
+        component: ServiceDeploymentsComponent
       }
     ]
   }

--- a/src/app/shared/feature-resolver/feature-resolver.service.ts
+++ b/src/app/shared/feature-resolver/feature-resolver.service.ts
@@ -27,6 +27,8 @@ export class FeatureResolverService extends FeatureStateResolver {
           return FeatureState.Enabled;
         case ApplicationFeature.CustomDashboards:
           return FeatureState.Enabled;
+        case ApplicationFeature.DeploymentMarkers:
+          return FeatureState.Disabled;
         default:
           return FeatureState.Enabled;
       }


### PR DESCRIPTION
## Deployment Markers Scaffolding PR for Route navigation, tabs and feature flag

Jira Reference: [OBSV-984](https://razorpay.atlassian.net/browse/OBSV-984)

- Added entry for `deployment-markers` in application feature list to enable feature flagging.
- Synced `config.json` file to be in sync with `configMap`.
- Updated `BreadCrumbService` to get last breadcrumb label directly, also added unit test for the same.
- Made resolutions of tabs dynamic in nature by maintaining the `ApplicationFeature` value. Also added test cases for the same. Also added property `flagName` to `NavigableTab`, this ensures that we can now dynamically resolve things.
- Added `ServiceDeploymentsModule` and the respective routing logic to navigate to `/deployments` and show the `ServiceDeploymentsComponent`.