### PR TITLE
Fixes the `edit` functionality for `panel` in custom dashboards

### DIFF
--- a/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel-edit/custom-dashboard-panel-edit.component.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel-edit/custom-dashboard-panel-edit.component.ts
@@ -211,6 +211,8 @@ export class CustomDashboardPanelEditComponent {
   public onSaveOrEditPanel(): void {
     const panelSlug = this.customDashboardService.convertNameToSlug(this.state.name);
     if (this.isNewDashboard) {
+      // In case of new dashboard, panel will also be new, so add a panel ID
+      this.state.id = panelSlug;
       this.customDashboardService
         .createDashboard({
           id: this.dashboardId,


### PR DESCRIPTION
## Issue
- Currently, when saving a new dashboard, the panel in the dashboard is given `id` as `''`.
- The route when you want to edit a panel becomes something like `:dashboard-id/:panel-id/`. So, it forms an empty string in the URL leading to something like `//`. Now Angular has an open [issue](https://github.com/angular/angular/issues/32853) for quite some time in case of optional `route` parameters.
- Owing to this, the route breaks and hence as a fallback, the user is redirected to `/error` page.

## Fix
- Added the logic to also create a new panel `id`, in case a panel is created in a new dashboard.

*Note: After the deployment, the users facing this issue will either have to clone/delete their existing panel(having this issue), as we cannot update the panel data dynamically*