### PR TITLE
feat [QoI]: improvements and fixes

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/category-card.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/category-card.component.ts
@@ -12,9 +12,7 @@ import { HeuristicClassScoreInfo } from '../service-instrumentation.types';
   template: `
     <div class="service-instrumentation-category-card" [style.border-top-color]="this.scoreColor">
       <h5 class="heading">{{ this.heuristicClassScore?.name }}</h5>
-      <p class="checks-status">
-        {{ this.getNoOfChecksPassing() }}/{{ this.heuristicClassScore?.heuristicScoreInfo.length }} checks passing
-      </p>
+      <p class="checks-status">{{ this.getNoOfChecksPassing() }}/{{ this.getTotalEligibleChecks() }} checks passing</p>
 
       <ht-service-instrumentation-progress-bar
         [score]="this.heuristicClassScore?.score"
@@ -63,6 +61,16 @@ export class CategoryCardComponent implements OnInit {
     return (
       this.heuristicClassScore?.heuristicScoreInfo?.reduce(
         (accumulator, currentParam) => (currentParam.score >= 70 ? accumulator + 1 : accumulator),
+        0
+      ) ?? 0
+    );
+  }
+
+  public getTotalEligibleChecks(): number {
+    // Checks with a score of -1 are skipped
+    return (
+      this.heuristicClassScore?.heuristicScoreInfo?.reduce(
+        (accumulator, currentParam) => (currentParam.score >= 0 ? accumulator + 1 : accumulator),
         0
       ) ?? 0
     );

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
@@ -26,6 +26,7 @@ describe('InstrumentationDetailsComponent', () => {
   });
 
   test('assigns correct color to icon', () => {
+    expect(component.getIconColor(-1)).toBe('#b7bfc2');
     expect(component.getIconColor(30)).toBe('#dc3d43');
   });
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
@@ -64,4 +64,19 @@ describe('InstrumentationDetailsComponent', () => {
       })
     ).toBe('This check was skipped as no eligible spans were present in the last evaluation');
   });
+
+  test('shows correct header summary when all spans passed check', () => {
+    expect(
+      component.getHeaderSummary({
+        sampleSize: '10',
+        failureCount: '0',
+        sampleType: 'span',
+        name: '',
+        description: '',
+        evalTimestamp: '',
+        sampleIds: [],
+        score: 1
+      })
+    ).toBe('All spans passed this check');
+  });
 });

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
@@ -62,6 +62,6 @@ describe('InstrumentationDetailsComponent', () => {
         sampleIds: [],
         score: -1.0
       })
-    ).toBe('This check was skipped as no eligible spans were present in the last evaluation.');
+    ).toBe('This check was skipped as no eligible spans were present in the last evaluation');
   });
 });

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
@@ -62,6 +62,6 @@ describe('InstrumentationDetailsComponent', () => {
         sampleIds: [],
         score: -1.0
       })
-    ).toBe('Check skipped as no eligible spans in this run');
+    ).toBe('This check was skipped as no eligible spans were present in the last evaluation.');
   });
 });

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -94,7 +94,7 @@ export class InstrumentationDetailsComponent {
 
     const sampleSize = Number(heuristicScore.sampleSize);
     const failureCount = Number(heuristicScore.failureCount);
-    const percentFailed = (failureCount / sampleSize) * 100;
+    const percentFailed = Math.round((failureCount / sampleSize) * 100);
 
     return `${percentFailed}% of ${heuristicScore.sampleType}s failed this check`;
   }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -85,7 +85,7 @@ export class InstrumentationDetailsComponent {
 
   public getHeaderSummary(heuristicScore: HeuristicScoreInfo): string {
     if (heuristicScore.score < 0) {
-      return 'Check skipped as no eligible spans in this run';
+      return 'This check was skipped as no eligible spans were present in the last evaluation.';
     }
 
     const sampleSize = Number(heuristicScore.sampleSize);

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -89,11 +89,11 @@ export class InstrumentationDetailsComponent {
 
   public getHeaderSummary(heuristicScore: HeuristicScoreInfo): string {
     if (heuristicScore.score < 0) {
-      return 'This check was skipped as no eligible spans were present in the last evaluation.';
+      return 'This check was skipped as no eligible spans were present in the last evaluation';
     }
 
     if (heuristicScore.failureCount === '0') {
-      return 'No spans failed this check';
+      return 'All spans passed this check';
     }
 
     const sampleSize = Number(heuristicScore.sampleSize);

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -92,6 +92,10 @@ export class InstrumentationDetailsComponent {
       return 'This check was skipped as no eligible spans were present in the last evaluation.';
     }
 
+    if (heuristicScore.failureCount === '0') {
+      return 'No spans failed this check';
+    }
+
     const sampleSize = Number(heuristicScore.sampleSize);
     const failureCount = Number(heuristicScore.failureCount);
     const percentFailed = Math.round((failureCount / sampleSize) * 100);

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -68,11 +68,11 @@ export class InstrumentationDetailsComponent {
   }
 
   public getHeaderIcon(score: number): string {
-    if (score < 50) {
+    if (score < 50 && score > -1) {
       return IconType.Close;
     }
 
-    if (score < 70) {
+    if (score < 70 && score > -1) {
       return IconType.Warning;
     }
 
@@ -80,6 +80,10 @@ export class InstrumentationDetailsComponent {
   }
 
   public getIconColor(score: number): string {
+    if (score < 0) {
+      return '#b7bfc2'; // $gray-3
+    }
+
     return this.serviceInstrumentationService.getColorForScore(score).dark;
   }
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
@@ -28,7 +28,7 @@ describe('PanelContentComponent', () => {
 
   test('shows correct evaluation date', () => {
     component.heuristicScore = {
-      evalTimestamp: '1665124368778',
+      evalTimestamp: '1665124368',
       name: '',
       sampleIds: [],
       description: '',

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
@@ -25,4 +25,19 @@ describe('PanelContentComponent', () => {
       '/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_1'
     );
   });
+
+  test('shows correct evaluation date', () => {
+    component.heuristicScore = {
+      evalTimestamp: '1665124368778',
+      name: '',
+      sampleIds: [],
+      description: '',
+      score: 0,
+      sampleType: 'span',
+      sampleSize: '0',
+      failureCount: '0'
+    };
+
+    expect(component.getEvaluationDate()).toBe('Fri, 07 Oct 2022');
+  });
 });

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
@@ -22,7 +22,7 @@ describe('PanelContentComponent', () => {
 
   test('navigates to Explorer page with trace ID filled', () => {
     expect(component.getExampleLink('1')).toBe(
-      '/explorer?time=1h&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_1'
+      '/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_1'
     );
   });
 });

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -33,7 +33,9 @@ export class PanelContentComponent {
   }
 
   public getEvaluationDate(): string {
-    const [day, month, date, year] = new Date(Number(this.heuristicScore?.evalTimestamp)).toDateString().split(' ');
+    const [day, month, date, year] = new Date(Number(this.heuristicScore?.evalTimestamp) * 1000)
+      .toDateString()
+      .split(' ');
 
     return `${day}, ${date} ${month} ${year}`;
   }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -17,6 +17,7 @@ import { HeuristicScoreInfo } from '../service-instrumentation.types';
         <span *ngIf="i < this.heuristicScore?.sampleIds.length - 1">, </span>
       </span>
     </p>
+    <p class="metric"><b>Evaluated on:</b> {{ this.getEvaluationDate() }}</p>
   `
 })
 export class PanelContentComponent {
@@ -29,5 +30,11 @@ export class PanelContentComponent {
     }
 
     return `/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_${id}`;
+  }
+
+  public getEvaluationDate(): string {
+    const [day, month, date, year] = new Date(Number(this.heuristicScore?.evalTimestamp)).toDateString().split(' ');
+
+    return `${day}, ${date} ${month} ${year}`;
   }
 }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -25,9 +25,9 @@ export class PanelContentComponent {
 
   public getExampleLink(id: string): string {
     if (this.heuristicScore?.sampleType === 'span') {
-      return `/explorer?time=1h&scope=spans&series=column:count(spans)&filter=id_eq_${id}`;
+      return `/explorer?time=1d&scope=spans&series=column:count(spans)&filter=id_eq_${id}`;
     }
 
-    return `/explorer?time=1h&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_${id}`;
+    return `/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_${id}`;
   }
 }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -10,7 +10,7 @@ import { HeuristicScoreInfo } from '../service-instrumentation.types';
     <p class="description">{{ this.heuristicScore?.description }}</p>
     <p class="metric"><b>Sample size:</b> {{ this.heuristicScore?.sampleSize }}</p>
     <p class="metric"><b>Failures:</b> {{ this.heuristicScore?.failureCount }}</p>
-    <p class="metric">
+    <p class="metric" *ngIf="this.heuristicScore?.sampleIds.length > 0">
       <b>Example {{ this.heuristicScore?.sampleType }}s: </b>
       <span *ngFor="let exampleId of this.heuristicScore?.sampleIds; let i = index">
         <a title="Open in Explorer" [href]="this.getExampleLink(exampleId)">{{ exampleId }}</a>

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.service.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.service.test.ts
@@ -23,16 +23,30 @@ describe('ServiceInstrumentationService', () => {
   });
 
   test('returns correct label for score', () => {
+    expect(service.getLabelForScore(30)).toBe('Below Expectation');
     expect(service.getLabelForScore(50)).toBe('Need Improvement');
+    expect(service.getLabelForScore(70)).toBe('Good');
+    expect(service.getLabelForScore(90)).toBe('Excellent!');
   });
 
   test('returns correct color for score', () => {
+    expect(service.getColorForScore(30).dark).toBe('#dc3d43');
     expect(service.getColorForScore(50).dark).toBe('#ffa01c');
+    expect(service.getColorForScore(70).dark).toBe('#3d9a50');
   });
 
   test('returns correct description for score', () => {
+    expect(service.getDescriptionForScore(30)).toBe(
+      'Attention is needed to improve the instrumentation of this service so you can start gaining valuable insights from Hypertrace.'
+    );
     expect(service.getDescriptionForScore(50)).toBe(
       'There is considerable scope for improvement. Please see the sections below to learn how to improve the instrumentation of this service.'
+    );
+    expect(service.getDescriptionForScore(70)).toBe(
+      'This service has good instrumentation, but you can still make improvements to gain more valuable insights from Hypertrace.'
+    );
+    expect(service.getDescriptionForScore(90)).toBe(
+      'Great job! This service has been instrumented using best practices.'
     );
   });
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.service.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.service.test.ts
@@ -23,7 +23,7 @@ describe('ServiceInstrumentationService', () => {
   });
 
   test('returns correct label for score', () => {
-    expect(service.getLabelForScore(50)).toBe('Average');
+    expect(service.getLabelForScore(50)).toBe('Need Improvement');
   });
 
   test('returns correct color for score', () => {

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.service.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.service.ts
@@ -24,15 +24,15 @@ export class ServiceInstrumentationService {
 
   public getLabelForScore(score: number): string {
     if (score < 50) {
-      return 'Below Average';
+      return 'Below Expectation';
     }
 
     if (score < 70) {
-      return 'Average';
+      return 'Need Improvement';
     }
 
     if (score < 90) {
-      return 'Above Average';
+      return 'Good';
     }
 
     return 'Excellent!';


### PR DESCRIPTION
## Description
[Jira](https://razorpay.atlassian.net/browse/OBSV-1073)

This PR addresses the fixes and feedback from stage testing by the Observability team.
Follow-up for #88 

- [x] Message for when QoI evaluation not done yet.
- [x] Changed labels for scores to remove the word "average".
- [x] All cards now have the same height and are slightly bigger.
- [x] "Example spans" field is omitted if no examples available.
- [x] More detailed summary message for skipped heuristics.
- [x] Skipped heuristics have a grey checkmark icon.
- [x] Skipped heuristics are not counted in total checks in overview screen cards.
- [x] Round off percent of spans failed.
- [x] Replace "0% spans failed" with "All spans passed".
- [x] Set example span time to 1 day in Explorer.
- [x] Using ht-button for card clicks, telemetry should work.
- [x] Display heuristic evaluation date.
- [x] Improved layout of cards, will split in 2 rows for narrow screens.

### Testing
Tested by team on stage environment.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works