### PR TITLE
feat [QoI]: add service name to filters for example spans

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { mockProvider } from '@ngneat/spectator/jest';
+import { of } from 'rxjs';
 
+import { BreadcrumbsService } from '@hypertrace/components';
 import { PanelContentComponent } from './panel-content.component';
 
 describe('PanelContentComponent', () => {
@@ -8,7 +11,12 @@ describe('PanelContentComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [PanelContentComponent]
+      declarations: [PanelContentComponent],
+      providers: [
+        mockProvider(BreadcrumbsService, {
+          getLastBreadCrumbString: () => of('x')
+        })
+      ]
     });
     fixture = TestBed.createComponent(PanelContentComponent);
     component = fixture.componentInstance;
@@ -22,7 +30,7 @@ describe('PanelContentComponent', () => {
 
   test('navigates to Explorer page with trace ID filled', () => {
     expect(component.getExampleLink('1')).toBe(
-      '/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_1'
+      '/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=serviceName_eq_x&filter=traceId_eq_1'
     );
   });
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
+import { BreadcrumbsService } from '@hypertrace/components';
 import { HeuristicScoreInfo } from '../service-instrumentation.types';
 
 @Component({
@@ -24,12 +25,18 @@ export class PanelContentComponent {
   @Input()
   public heuristicScore: HeuristicScoreInfo | undefined;
 
+  private serviceName: string = '';
+
+  public constructor(private readonly breadcrumbsService: BreadcrumbsService) {
+    this.breadcrumbsService.getLastBreadCrumbString().subscribe(serviceName => (this.serviceName = serviceName));
+  }
+
   public getExampleLink(id: string): string {
     if (this.heuristicScore?.sampleType === 'span') {
-      return `/explorer?time=1d&scope=spans&series=column:count(spans)&filter=id_eq_${id}`;
+      return `/explorer?time=1d&scope=spans&series=column:count(spans)&filter=serviceName_eq_${this.serviceName}&filter=id_eq_${id}`;
     }
 
-    return `/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=traceId_eq_${id}`;
+    return `/explorer?time=1d&scope=endpoint-traces&series=column:count(calls)&filter=serviceName_eq_${this.serviceName}&filter=traceId_eq_${id}`;
   }
 
   public getEvaluationDate(): string {


### PR DESCRIPTION
## Description
Example spans in QoI are loading slow. To reduce the lag, adding service name to the filters applied when clicking on an example span. [[Slack][1]]

### Testing
Testing on stage & prod by team.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

[1]: https://razorpay.slack.com/archives/CU5GKS8MQ/p1665601990344249?thread_ts=1664523417.972659&cid=CU5GKS8MQ