### PR TITLE
feat [QoI]: change org score label to show comparison

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-overview.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-overview.component.ts
@@ -17,6 +17,7 @@ import { OrgScoreResponse, ServiceScoreResponse } from '../service-instrumentati
         ></ht-service-instrumentation-total-score>
 
         <ht-service-instrumentation-org-score
+          [serviceScore]="(this.serviceScoreSubject | async)?.aggregatedWeightedScore"
           [orgScore]="this.orgScoreResponse?.aggregatedWeightedScore"
           *ngIf="this.showOrgScores | async"
         ></ht-service-instrumentation-org-score>

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.test.ts
@@ -1,7 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { mockProvider } from '@ngneat/spectator/jest';
 
-import { ServiceInstrumentationService } from '../service-instrumentation.service';
 import { OrgScoreComponent } from './org-score.component';
 
 describe('OrgScoreComponent', () => {
@@ -10,13 +8,7 @@ describe('OrgScoreComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [OrgScoreComponent],
-      providers: [
-        mockProvider(ServiceInstrumentationService, {
-          getLabelForScore: () => 'label',
-          getColorForScore: () => ({ dark: 'dark' })
-        })
-      ]
+      declarations: [OrgScoreComponent]
     });
     fixture = TestBed.createComponent(OrgScoreComponent);
     component = fixture.componentInstance;
@@ -29,10 +21,28 @@ describe('OrgScoreComponent', () => {
   });
 
   test('assigns correct label for score', () => {
-    expect(component.scoreLabel).toBe('label');
+    component.orgScore = 50;
+
+    component.serviceScore = 60;
+    expect(component.getScoreComment().text).toBe('The service score is above the org score');
+
+    component.serviceScore = 50;
+    expect(component.getScoreComment().text).toBe('The service score matches the org score');
+
+    component.serviceScore = 40;
+    expect(component.getScoreComment().text).toBe('The service score is below the org score');
   });
 
   test('assigns correct color for score', () => {
-    expect(component.scoreColor).toBe('dark');
+    component.orgScore = 50;
+
+    component.serviceScore = 60;
+    expect(component.getScoreComment().color).toBe('#3d9a50');
+
+    component.serviceScore = 50;
+    expect(component.getScoreComment().color).toBe('#3d9a50');
+
+    component.serviceScore = 40;
+    expect(component.getScoreComment().color).toBe('#dc3d43');
   });
 });

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.ts
@@ -1,5 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { ServiceInstrumentationService } from '../service-instrumentation.service';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   styleUrls: ['./org-score.component.scss'],
@@ -8,26 +7,31 @@ import { ServiceInstrumentationService } from '../service-instrumentation.servic
   template: `
     <div class="service-instrumentation-org-score">
       <div>
-        <h5 class="heading">Razorpay Average</h5>
+        <h5 class="heading">Organization Score</h5>
         <p class="score">
           {{ this.orgScore | number: '1.0-0' }}
-          <span class="label" [style.color]="this.scoreColor">{{ this.scoreLabel }}</span>
+          <span class="label" [style.color]="this.getScoreComment().color">{{ this.getScoreComment().text }}</span>
         </p>
       </div>
     </div>
   `
 })
-export class OrgScoreComponent implements OnInit {
+export class OrgScoreComponent {
+  @Input()
+  public serviceScore: number = 0;
+
   @Input()
   public orgScore: number = 0;
 
-  public scoreLabel: string = '';
-  public scoreColor: string = '';
+  public getScoreComment(): { text: string; color: string } {
+    if (this.serviceScore > this.orgScore) {
+      return { text: 'The service score is above the org score', color: '#3d9a50' };
+    }
 
-  public constructor(private readonly serviceInstrumentationService: ServiceInstrumentationService) {}
+    if (this.serviceScore === this.orgScore) {
+      return { text: 'The service score matches the org score', color: '#3d9a50' };
+    }
 
-  public ngOnInit(): void {
-    this.scoreLabel = this.serviceInstrumentationService.getLabelForScore(this.orgScore);
-    this.scoreColor = this.serviceInstrumentationService.getColorForScore(this.orgScore).dark;
+    return { text: 'The service score is below the org score', color: '#dc3d43' };
   }
 }


### PR DESCRIPTION
## Description
Modified org score comment in QoI overview to indicate how the service score compares to it.
Also changed org label from "Razorpay Average" to "Organization Score".

<img width="1233" alt="Screenshot 2022-10-13 at 3 30 08 PM" src="https://user-images.githubusercontent.com/29686866/195570150-d9801748-02ec-4a2f-aff9-e0ecb167b5de.png">

### Testing
Tested by team on stage and prod.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works