### PR TITLE
fix [QoI]: round off scores before comparing

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.test.ts
@@ -21,12 +21,12 @@ describe('OrgScoreComponent', () => {
   });
 
   test('assigns correct label for score', () => {
-    component.orgScore = 50;
+    component.orgScore = 50.87;
 
     component.serviceScore = 60;
     expect(component.getScoreComment().text).toBe('The service score is above the org score');
 
-    component.serviceScore = 50;
+    component.serviceScore = 50.68;
     expect(component.getScoreComment().text).toBe('The service score matches the org score');
 
     component.serviceScore = 40;
@@ -34,12 +34,12 @@ describe('OrgScoreComponent', () => {
   });
 
   test('assigns correct color for score', () => {
-    component.orgScore = 50;
+    component.orgScore = 50.87;
 
     component.serviceScore = 60;
     expect(component.getScoreComment().color).toBe('#3d9a50');
 
-    component.serviceScore = 50;
+    component.serviceScore = 50.68;
     expect(component.getScoreComment().color).toBe('#3d9a50');
 
     component.serviceScore = 40;

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/org-score.component.ts
@@ -24,11 +24,14 @@ export class OrgScoreComponent {
   public orgScore: number = 0;
 
   public getScoreComment(): { text: string; color: string } {
-    if (this.serviceScore > this.orgScore) {
+    const serviceScore = Math.round(this.serviceScore);
+    const orgScore = Math.round(this.orgScore);
+
+    if (serviceScore > orgScore) {
       return { text: 'The service score is above the org score', color: '#3d9a50' };
     }
 
-    if (this.serviceScore === this.orgScore) {
+    if (serviceScore === orgScore) {
       return { text: 'The service score matches the org score', color: '#3d9a50' };
     }
 


### PR DESCRIPTION
## Description
UI doesn't display decimals to the user so the service and org scores should be rounded off before comparing them to avoid showing a wrong comment where the scores differ only by decimal. [[Slack](https://razorpay.slack.com/archives/CU5GKS8MQ/p1665658059585719?thread_ts=1665649853.529319&cid=CU5GKS8MQ)]

### Testing
Tested by team on stage and prod.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works