### PR TITLE
Handle delimiter in `sampleIds` and add support for trace/span `startTime`

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
@@ -29,8 +29,8 @@ describe('PanelContentComponent', () => {
   });
 
   test('navigates to Explorer page with trace ID filled', () => {
-    expect(component.getExampleLink('1')).toBe(
-      '/explorer?time=12h&scope=endpoint-traces&series=column:count(calls)&filter=serviceName_eq_x&filter=traceId_eq_1'
+    expect(component.getExampleLink('traceId:startTime')).toBe(
+      '/explorer?time=12h&scope=endpoint-traces&series=column:count(calls)&filter=serviceName_eq_x&filter=startTime_eq_startTime'
     );
   });
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -46,22 +46,28 @@ export class PanelContentComponent {
   }
 
   public getExampleLink(id: SampleHeuristicEnityId<SAMPLE_HEURISTIC_ENTITY_DELIMETER>): string {
+    const [heuristicEntityId, heuristicEntityStartTime] = id.split(this.SAMPLE_DELIMETER);
     const exampleGeneratedUrl =
       this.heuristicScore?.sampleType === 'span'
         ? `/explorer?time=${this.timeDuration}&scope=spans&series=column:count(spans)`
         : `/explorer?time=${this.timeDuration}&scope=endpoint-traces&series=column:count(calls)`;
 
-    const [heuristicEntityId, heuristicEntityStartTime] = id.split(this.SAMPLE_DELIMETER);
-    const filtersToApply = [
-      { key: 'id', value: heuristicEntityId, operator: 'eq' },
+    const explorerFiltersToApply = [
       { key: 'serviceName', value: this.serviceName, operator: 'eq' },
-      { key: 'startTime', value: heuristicEntityStartTime, operator: 'eq' }
+      { key: 'startTime', value: heuristicEntityStartTime, operator: 'eq' },
+      { key: 'id', value: heuristicEntityId, operator: 'eq', scope: 'span' },
+      { key: 'traceId', value: heuristicEntityId, operator: 'eq', scope: 'trace' }
     ];
 
-    return filtersToApply.reduce(
-      (previousValue, currValue) => `${previousValue}&filter=${currValue.key}_${currValue.operator}_${currValue.value}`,
-      exampleGeneratedUrl
-    );
+    return explorerFiltersToApply
+      .filter(
+        explorerFilter => explorerFilter.scope === undefined || explorerFilter.scope === this.heuristicScore?.sampleType
+      )
+      .reduce(
+        (previousValue, currValue) =>
+          `${previousValue}&filter=${currValue.key}_${currValue.operator}_${currValue.value}`,
+        exampleGeneratedUrl
+      );
   }
 
   public getEvaluationDate(): string {

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.ts
@@ -1,7 +1,11 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { BreadcrumbsService } from '@hypertrace/components';
-import { HeuristicScoreInfo } from '../service-instrumentation.types';
+import {
+  HeuristicScoreInfo,
+  SampleHeuristicEnityId,
+  SAMPLE_HEURISTIC_ENTITY_DELIMETER
+} from '../service-instrumentation.types';
 
 @Component({
   styleUrls: ['./panel-content.component.scss'],
@@ -14,7 +18,9 @@ import { HeuristicScoreInfo } from '../service-instrumentation.types';
     <p class="metric" *ngIf="this.heuristicScore?.sampleIds.length > 0">
       <b>Example {{ this.heuristicScore?.sampleType }}s: </b>
       <span *ngFor="let exampleId of this.heuristicScore?.sampleIds; let i = index">
-        <a title="Open in Explorer" [href]="this.getExampleLink(exampleId)">{{ exampleId }}</a>
+        <a target="_blank" title="Open in Explorer" [href]="this.getExampleLink(exampleId)">{{
+          this.getExampleHeuristicEntityId(exampleId)
+        }}</a>
         <span *ngIf="i < this.heuristicScore?.sampleIds.length - 1">, </span>
       </span>
     </p>
@@ -26,17 +32,36 @@ export class PanelContentComponent {
   public heuristicScore: HeuristicScoreInfo | undefined;
 
   private serviceName: string = '';
+  private readonly timeDuration: string = '12h';
+  private readonly SAMPLE_DELIMETER: SAMPLE_HEURISTIC_ENTITY_DELIMETER = ':';
 
   public constructor(private readonly breadcrumbsService: BreadcrumbsService) {
     this.breadcrumbsService.getLastBreadCrumbString().subscribe(serviceName => (this.serviceName = serviceName));
   }
 
-  public getExampleLink(id: string): string {
-    if (this.heuristicScore?.sampleType === 'span') {
-      return `/explorer?time=12h&scope=spans&series=column:count(spans)&filter=serviceName_eq_${this.serviceName}&filter=id_eq_${id}`;
-    }
+  public getExampleHeuristicEntityId(sampleId: SampleHeuristicEnityId<SAMPLE_HEURISTIC_ENTITY_DELIMETER>): string {
+    const [entityId] = sampleId.split(this.SAMPLE_DELIMETER);
 
-    return `/explorer?time=12h&scope=endpoint-traces&series=column:count(calls)&filter=serviceName_eq_${this.serviceName}&filter=traceId_eq_${id}`;
+    return entityId ?? '';
+  }
+
+  public getExampleLink(id: SampleHeuristicEnityId<SAMPLE_HEURISTIC_ENTITY_DELIMETER>): string {
+    const exampleGeneratedUrl =
+      this.heuristicScore?.sampleType === 'span'
+        ? `/explorer?time=${this.timeDuration}&scope=spans&series=column:count(spans)`
+        : `/explorer?time=${this.timeDuration}&scope=endpoint-traces&series=column:count(calls)`;
+
+    const [heuristicEntityId, heuristicEntityStartTime] = id.split(this.SAMPLE_DELIMETER);
+    const filtersToApply = [
+      { key: 'id', value: heuristicEntityId, operator: 'eq' },
+      { key: 'serviceName', value: this.serviceName, operator: 'eq' },
+      { key: 'startTime', value: heuristicEntityStartTime, operator: 'eq' }
+    ];
+
+    return filtersToApply.reduce(
+      (previousValue, currValue) => `${previousValue}&filter=${currValue.key}_${currValue.operator}_${currValue.value}`,
+      exampleGeneratedUrl
+    );
   }
 
   public getEvaluationDate(): string {

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.fixture.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.fixture.ts
@@ -14,7 +14,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'HasMeaningfulEndpointName',
           evalTimestamp: '1658434128',
           score: 70.0,
-          sampleIds: ['5dea74f41f728fd91c7', '5dea74asdas1'],
+          sampleIds: ['5dea74f41f728fd91c7:1665992993880', '5dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '1000',
           failureCount: '200'
@@ -24,7 +24,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'HasUniqueClientSpans',
           evalTimestamp: '1658434286',
           score: 25.0,
-          sampleIds: ['95ea74f41f728fd91c7', 'asddea74asdas1'],
+          sampleIds: ['95ea74f41f728fd91c7:1665992993880', 'asddea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '1000',
           failureCount: '250'
@@ -41,7 +41,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'HasNoTokens',
           evalTimestamp: '1658434128',
           score: 60.0,
-          sampleIds: ['m5dea7728fd91c7', 'n1235dea74asdas1'],
+          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
           failureCount: '90'
@@ -58,7 +58,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'HasNoTokens',
           evalTimestamp: '1658434128',
           score: 70.0,
-          sampleIds: ['m5dea7728fd91c7', 'n1235dea74asdas1'],
+          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
           failureCount: '30'
@@ -68,7 +68,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'SecondHeuristic',
           evalTimestamp: '1658434128',
           score: 50.0,
-          sampleIds: ['m5dea7728fd91c7', 'n1235dea74asdas1'],
+          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
           failureCount: '50'
@@ -79,7 +79,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'ThirdHeuristic',
           evalTimestamp: '1658434128',
           score: 30.0,
-          sampleIds: ['m5dea7728fd91c8', 'n1235dea74asdas1'],
+          sampleIds: ['m5dea7728fd91c8:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'trace',
           sampleSize: '100',
           failureCount: '70'
@@ -96,7 +96,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'HasNoTokens',
           evalTimestamp: '1658434128',
           score: 90.0,
-          sampleIds: ['m5dea7728fd91c7', 'n1235dea74asdas1'],
+          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
           failureCount: '10'
@@ -106,7 +106,7 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           name: 'SecondHeuristic',
           evalTimestamp: '1658434128',
           score: -1.0,
-          sampleIds: ['m5dea7728fd91c7', 'n1235dea74asdas1'],
+          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
           failureCount: '90'

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.types.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.types.ts
@@ -3,7 +3,7 @@ export interface HeuristicScoreInfo {
   description: string;
   evalTimestamp: string;
   score: number;
-  sampleIds: string[];
+  sampleIds: SampleHeuristicEnityId<SAMPLE_HEURISTIC_ENTITY_DELIMETER>[];
   sampleType: string;
   sampleSize: string;
   failureCount: string;
@@ -27,3 +27,7 @@ export interface OrgScoreResponse {
   heuristicClassScoreInfo: HeuristicClassScoreInfo[];
   aggregatedWeightedScore: number;
 }
+
+export type SampleHeuristicEnityId<Delimeter extends string> = `${string}${Delimeter}${string}`;
+
+export type SAMPLE_HEURISTIC_ENTITY_DELIMETER = ':' | ',';

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.types.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.types.ts
@@ -4,7 +4,7 @@ export interface HeuristicScoreInfo {
   evalTimestamp: string;
   score: number;
   sampleIds: SampleHeuristicEnityId<SAMPLE_HEURISTIC_ENTITY_DELIMETER>[];
-  sampleType: string;
+  sampleType: 'span' | 'trace';
   sampleSize: string;
   failureCount: string;
 }
@@ -30,4 +30,4 @@ export interface OrgScoreResponse {
 
 export type SampleHeuristicEnityId<Delimeter extends string> = `${string}${Delimeter}${string}`;
 
-export type SAMPLE_HEURISTIC_ENTITY_DELIMETER = ':' | ',';
+export type SAMPLE_HEURISTIC_ENTITY_DELIMETER = ':' | ', ';


### PR DESCRIPTION
- Stricter `type` definition for `sampleId`, `sampleType`.
- Link for respective `span` or `trace` will now open in new tab.
- Handling for `:` delimiter in `sampleIds`.
- Added `startTime` in the explorer page filter.