### PR TITLE
Rounding off fix for % of spans failed

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.test.ts
@@ -48,7 +48,7 @@ describe('InstrumentationDetailsComponent', () => {
         sampleIds: [],
         score: 0
       })
-    ).toBe('90% of spans failed this check');
+    ).toBe('~90% of spans failed this check');
   });
 
   test('shows correct header summary when check is not eligible', () => {

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -98,8 +98,8 @@ export class InstrumentationDetailsComponent {
 
     const sampleSize = Number(heuristicScore.sampleSize);
     const failureCount = Number(heuristicScore.failureCount);
-    const percentFailed = Math.round((failureCount / sampleSize) * 100);
+    const percentFailed = Math.min(Math.ceil((failureCount / sampleSize) * 100), 100);
 
-    return `${percentFailed}% of ${heuristicScore.sampleType}s failed this check`;
+    return `~${percentFailed}% of ${heuristicScore.sampleType}s failed this check`;
   }
 }


### PR DESCRIPTION
- For cases when % of spans failing check are `0.5%` or having such values, UI shows `0% spans failed this check`.
  - This fix ensures that we are doing `Math.ceil` instead of round off, and also adds a `~` sign to show that it's a rough estimate.
  
![image](https://user-images.githubusercontent.com/56739130/196935969-8612a1ca-d969-4296-81b7-ef5e24ad528c.png)
