### PR TITLE
fix [QoI]: time range within 30 minutes around timestamp

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/category-card.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/category-card.component.ts
@@ -20,7 +20,7 @@ import { HeuristicClassScoreInfo } from '../service-instrumentation.types';
 
       <ht-service-instrumentation-progress-bar
         *ngIf="this.orgCategoryScores"
-        label="Razorpay Average"
+        label="Organization Average"
         [score]="this.getOrgScoreForCategory()"
       ></ht-service-instrumentation-progress-bar>
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/panel-content.component.test.ts
@@ -29,8 +29,8 @@ describe('PanelContentComponent', () => {
   });
 
   test('navigates to Explorer page with trace ID filled', () => {
-    expect(component.getExampleLink('traceId:startTime')).toBe(
-      '/explorer?time=12h&scope=endpoint-traces&series=column:count(calls)&filter=serviceName_eq_x&filter=startTime_eq_startTime'
+    expect(component.getExampleLink('traceId:2000')).toBe(
+      '/explorer?time=200-3800&scope=endpoint-traces&series=column:count(calls)'
     );
   });
 

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.test.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { InstrumentationQualityService } from '@hypertrace/common';
+import { InstrumentationQualityService, SubscriptionLifecycle } from '@hypertrace/common';
 import { mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
@@ -20,7 +20,8 @@ describe('ServiceInstrumentationComponent', () => {
         mockProvider(ServiceInstrumentationService),
         mockProvider(InstrumentationQualityService, {
           getServiceScore: () => of(serviceScoreResponse)
-        })
+        }),
+        mockProvider(SubscriptionLifecycle)
       ]
     });
     fixture = TestBed.createComponent(ServiceInstrumentationComponent);

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 import { SubscriptionLifecycle } from '@hypertrace/common';
@@ -24,22 +24,21 @@ import { ServiceScoreResponse } from './service-instrumentation.types';
     <ng-template #loader> <ht-loader></ht-loader></ng-template>
   `
 })
-export class ServiceInstrumentationComponent implements OnInit {
+export class ServiceInstrumentationComponent implements AfterViewInit {
   public constructor(
     private readonly breadcrumbsService: BreadcrumbsService,
     private readonly serviceInstrumentationService: ServiceInstrumentationService,
     private readonly subscriptionLifecycle: SubscriptionLifecycle
   ) {}
 
-  public ngOnInit(): void {
+  public ngAfterViewInit(): void {
     this.subscriptionLifecycle.add(
       this.breadcrumbsService.getLastBreadCrumbString().subscribe(serviceName => {
-        serviceName !== 'Services' &&
-          this.subscriptionLifecycle.add(
-            this.serviceInstrumentationService
-              .getServiceScore(serviceName)
-              .subscribe(serviceScore => this.serviceInstrumentationService.serviceScoreSubject.next(serviceScore))
-          );
+        this.subscriptionLifecycle.add(
+          this.serviceInstrumentationService
+            .getServiceScore(serviceName)
+            .subscribe(serviceScore => this.serviceInstrumentationService.serviceScoreSubject.next(serviceScore))
+        );
       })
     );
   }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
@@ -34,11 +34,12 @@ export class ServiceInstrumentationComponent implements OnInit {
   public ngOnInit(): void {
     this.subscriptionLifecycle.add(
       this.breadcrumbsService.getLastBreadCrumbString().subscribe(serviceName => {
-        this.subscriptionLifecycle.add(
-          this.serviceInstrumentationService
-            .getServiceScore(serviceName)
-            .subscribe(serviceScore => this.serviceInstrumentationService.serviceScoreSubject.next(serviceScore))
-        );
+        serviceName !== 'Services' &&
+          this.subscriptionLifecycle.add(
+            this.serviceInstrumentationService
+              .getServiceScore(serviceName)
+              .subscribe(serviceScore => this.serviceInstrumentationService.serviceScoreSubject.next(serviceScore))
+          );
       })
     );
   }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 import { SubscriptionLifecycle } from '@hypertrace/common';
@@ -24,14 +24,14 @@ import { ServiceScoreResponse } from './service-instrumentation.types';
     <ng-template #loader> <ht-loader></ht-loader></ng-template>
   `
 })
-export class ServiceInstrumentationComponent implements AfterViewInit {
+export class ServiceInstrumentationComponent implements AfterContentInit {
   public constructor(
     private readonly breadcrumbsService: BreadcrumbsService,
     private readonly serviceInstrumentationService: ServiceInstrumentationService,
     private readonly subscriptionLifecycle: SubscriptionLifecycle
   ) {}
 
-  public ngAfterViewInit(): void {
+  public ngAfterContentInit(): void {
     this.subscriptionLifecycle.add(
       this.breadcrumbsService.getLastBreadCrumbString().subscribe(serviceName => {
         this.subscriptionLifecycle.add(

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.types.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.types.ts
@@ -3,7 +3,7 @@ export interface HeuristicScoreInfo {
   description: string;
   evalTimestamp: string;
   score: number;
-  sampleIds: SampleHeuristicEnityId<SAMPLE_HEURISTIC_ENTITY_DELIMETER>[];
+  sampleIds: SampleHeuristicEntityId<SAMPLE_HEURISTIC_ENTITY_DELIMITER>[];
   sampleType: 'span' | 'trace';
   sampleSize: string;
   failureCount: string;
@@ -28,6 +28,6 @@ export interface OrgScoreResponse {
   aggregatedWeightedScore: number;
 }
 
-export type SampleHeuristicEnityId<Delimeter extends string> = `${string}${Delimeter}${string}`;
+export type SampleHeuristicEntityId<Delimiter extends string> = `${string}${Delimiter}${string}`;
 
-export type SAMPLE_HEURISTIC_ENTITY_DELIMETER = ':' | ', ';
+export type SAMPLE_HEURISTIC_ENTITY_DELIMITER = ':';


### PR DESCRIPTION
## Description

High priority prod fixes for QoI

- [x] Removed "Service Name" from Example spans/traces since the Explorer results show the name of the starting span, not the one belonging to the Span ID.
- [x] Removed "Start Time" from Example spans/traces and instead changed the URL to use a custom time range around the example timestamp.
- [x] Fixed wrong evaluation message being shown instead of spinner for a few seconds on initial load.

Minor changes

- Changed "Razorpay" to "Organization" in category cards.
- Removed `, ` as delimiter for `sampleIds` in QoI response.
- Added missing subscription lifecycles.
- Fixed typos.

### Testing
Tested on stage.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
