### PR TITLE
fix [QoI]: wrong message on navigation from Services

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.component.ts
@@ -34,11 +34,12 @@ export class ServiceInstrumentationComponent implements AfterContentInit {
   public ngAfterContentInit(): void {
     this.subscriptionLifecycle.add(
       this.breadcrumbsService.getLastBreadCrumbString().subscribe(serviceName => {
-        this.subscriptionLifecycle.add(
-          this.serviceInstrumentationService
-            .getServiceScore(serviceName)
-            .subscribe(serviceScore => this.serviceInstrumentationService.serviceScoreSubject.next(serviceScore))
-        );
+        serviceName !== 'Services' &&
+          this.subscriptionLifecycle.add(
+            this.serviceInstrumentationService
+              .getServiceScore(serviceName)
+              .subscribe(serviceScore => this.serviceInstrumentationService.serviceScoreSubject.next(serviceScore))
+          );
       })
     );
   }


### PR DESCRIPTION
## Description

[Jira][2] | [Slack][3]

The service-instrumentation component relies on the BreadcrumbService to get the serviceName. If the user navigates to the `/instrumentation` tab before breadcrumbs are finished loading, the serviceName is returned as `'Services'` leading to an incorrect initialisation of the component which shows the wrong message for few seconds to users before correct call is made. This change will make sure API call is not made if breadcrumb is returned as `'Services'`, eliminating this edge case. Tried [alternate approaches][1] but they didn't work.

Another way to fix this is to run the breadcrumb-read and API-fetch code inside an AfterViewInit lifecycle hook but that will fail all tests associated with the component so we'll have to delete them.

### Testing
Tested on stage.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

[1]: https://github.com/razorpay/hypertrace-ui/pull/97#discussion_r1007085006
[2]: https://razorpay.atlassian.net/browse/OBSV-1106
[3]: https://razorpay.slack.com/archives/CU5GKS8MQ/p1666954608316379