### PR TITLE
fix: large legend shrinks chart in Explorer

### DIFF
--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.scss
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.scss
@@ -105,8 +105,8 @@
 
     .legend-entries {
       /* Prevent large legends from shrinking chart */
-      max-height: 3.5rem;
-      overflow: auto;
+      max-height: 60px;
+      overflow-y: auto;
 
       padding-right: 8px;
       display: flex;

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.scss
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.scss
@@ -104,6 +104,10 @@
     }
 
     .legend-entries {
+      /* Prevent large legends from shrinking chart */
+      max-height: 3.5rem;
+      overflow: auto;
+
       padding-right: 8px;
       display: flex;
       flex-wrap: wrap;

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.scss
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.scss
@@ -146,6 +146,12 @@
         }
 
         .legend-text {
+          /* Add ellipsis for long text */
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          width: 200px;
+
           font-size: 14px;
           padding-left: 2px;
 

--- a/projects/observability/src/shared/components/cartesian/d3/legend/cartesian-legend.ts
+++ b/projects/observability/src/shared/components/cartesian/d3/legend/cartesian-legend.ts
@@ -158,7 +158,8 @@ export class CartesianLegend<TData> {
       .append('span')
       .classed('legend-text', true)
       .classed(CartesianLegend.SELECTABLE_CSS_CLASS, this.series.length > 1)
-      .text(series => series.name)
+      .text(series => this.truncateLongText(series.name, 35))
+      .attr('title', series => series.name)
       .on('click', series => (this.series.length > 1 ? this.updateActiveSeries(series) : undefined));
 
     this.updateLegendClassesAndStyle();
@@ -291,5 +292,9 @@ export class CartesianLegend<TData> {
 
   private isThisLegendSeriesGroupActive(seriesGroup: Series<TData>[]): boolean {
     return !this.isSelectionModeOn ? false : seriesGroup.every(series => this.activeSeries.includes(series));
+  }
+
+  private truncateLongText(text: string, maxLength: number): string {
+    return text.length > maxLength ? text.slice(0, maxLength - 3).concat('...') : text;
   }
 }

--- a/projects/observability/src/shared/components/cartesian/d3/legend/cartesian-legend.ts
+++ b/projects/observability/src/shared/components/cartesian/d3/legend/cartesian-legend.ts
@@ -158,7 +158,7 @@ export class CartesianLegend<TData> {
       .append('span')
       .classed('legend-text', true)
       .classed(CartesianLegend.SELECTABLE_CSS_CLASS, this.series.length > 1)
-      .text(series => this.truncateLongText(series.name, 35))
+      .text(series => series.name)
       .attr('title', series => series.name)
       .on('click', series => (this.series.length > 1 ? this.updateActiveSeries(series) : undefined));
 
@@ -292,9 +292,5 @@ export class CartesianLegend<TData> {
 
   private isThisLegendSeriesGroupActive(seriesGroup: Series<TData>[]): boolean {
     return !this.isSelectionModeOn ? false : seriesGroup.every(series => this.activeSeries.includes(series));
-  }
-
-  private truncateLongText(text: string, maxLength: number): string {
-    return text.length > maxLength ? text.slice(0, maxLength - 3).concat('...') : text;
   }
 }


### PR DESCRIPTION
## Description

[Jira][1]

Fixes the bug for both Explorer screen and Custom Dashboard panels.

### Screenshots

|Before|
|:-----:|
| <img width="1015" alt="before" src="https://user-images.githubusercontent.com/29686866/199890546-f8fba39e-f046-453d-83fc-f88869143043.png"> |
|After|
| <img width="1015" alt="after" src="https://user-images.githubusercontent.com/29686866/199890604-781df21a-05ba-484b-b5da-b2d0b95f86d5.png"> |

### Testing
Test on [stage environment][2]

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

[1]: https://razorpay.atlassian.net/browse/OBSV-1108
[2]: https://hypertrace.concierge.stage.razorpay.in/explorer?time=1h&scope=spans&series=column:count(spans)&filter=serviceName_eq_api&filter=spanTags_ck_db.system&group=spanTags__db.statement&limit=10