### PR TITLE
feat [QoI]: raise failure threshold for security

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/category-card.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/category-card.component.ts
@@ -58,9 +58,11 @@ export class CategoryCardComponent implements OnInit {
   }
 
   public getNoOfChecksPassing(): number {
+    const failureThreshold = this.heuristicClassScore?.name === 'Security' ? 100 : 70;
+
     return (
       this.heuristicClassScore?.heuristicScoreInfo?.reduce(
-        (accumulator, currentParam) => (currentParam.score >= 70 ? accumulator + 1 : accumulator),
+        (accumulator, currentParam) => (currentParam.score >= failureThreshold ? accumulator + 1 : accumulator),
         0
       ) ?? 0
     );

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/instrumentation-details.component.ts
@@ -68,7 +68,9 @@ export class InstrumentationDetailsComponent {
   }
 
   public getHeaderIcon(score: number): string {
-    if (score < 50 && score > -1) {
+    const failureThreshold = this.heuristicClassScore?.name === 'Security' ? 100 : 50;
+
+    if (score < failureThreshold && score > -1) {
       return IconType.Close;
     }
 
@@ -82,6 +84,10 @@ export class InstrumentationDetailsComponent {
   public getIconColor(score: number): string {
     if (score < 0) {
       return '#b7bfc2'; // $gray-3
+    }
+
+    if (this.heuristicClassScore?.name === 'Security' && score < 100) {
+      return this.serviceInstrumentationService.getColorForScore(0).dark;
     }
 
     return this.serviceInstrumentationService.getColorForScore(score).dark;

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/progress-bar.component.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/progress-bar.component.test.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { mockProvider } from '@ngneat/spectator/jest';
+import { ServiceInstrumentationService } from '../service-instrumentation.service';
+
+import { ProgressBarComponent } from './progress-bar.component';
+
+describe('Instrumentation Quality: ProgressBarComponent', () => {
+  let component: ProgressBarComponent;
+  let fixture: ComponentFixture<ProgressBarComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProgressBarComponent],
+      providers: [
+        mockProvider(ServiceInstrumentationService, {
+          getColorForScore: () => ({ dark: '' })
+        })
+      ]
+    });
+    fixture = TestBed.createComponent(ProgressBarComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  test('should be created successfully', () => {
+    expect(component).toBeDefined();
+  });
+
+  test('floor method rounds down decimals', () => {
+    expect(component.floor(99.99)).toBe(99);
+  });
+});

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/components/progress-bar.component.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/components/progress-bar.component.ts
@@ -10,7 +10,7 @@ import { ServiceInstrumentationService } from '../service-instrumentation.servic
       <div class="score-info">
         <label>{{ this.label }}</label>
         <p class="score">
-          {{ this.score | number: '1.0-0' }}
+          {{ this.floor(this.score) }}
         </p>
       </div>
 
@@ -31,5 +31,9 @@ export class ProgressBarComponent implements OnInit {
 
   public ngOnInit(): void {
     this.scoreColor = this.serviceInstrumentationService.getColorForScore(this.score).dark;
+  }
+
+  public floor(num: number): number {
+    return Math.floor(num);
   }
 }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.fixture.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.fixture.ts
@@ -50,66 +50,28 @@ export const serviceScoreResponse: ServiceScoreResponse = {
     },
     {
       name: 'Security',
-      score: 70.0,
+      score: 100.0,
       description: 'Trace security refers to the quality of the existing metadata in spans/traces.',
       heuristicScoreInfo: [
         {
           description: 'Single paragraph description for this heuristic.',
-          name: 'HasNoTokens',
+          name: 'PCI Info in Span',
           evalTimestamp: '1658434128',
-          score: 70.0,
+          score: 100.0,
           sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
-          failureCount: '30'
+          failureCount: '0'
         },
         {
           description: 'Single paragraph description for this heuristic.',
-          name: 'SecondHeuristic',
+          name: 'PII Info in Span',
           evalTimestamp: '1658434128',
-          score: 50.0,
+          score: 99.99,
           sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
           sampleType: 'span',
           sampleSize: '100',
-          failureCount: '50'
-        },
-        {
-          description:
-            'Single paragraph description for this heuristic. Single paragraph description for this heuristic. Single paragraph description for this heuristic.',
-          name: 'ThirdHeuristic',
-          evalTimestamp: '1658434128',
-          score: 30.0,
-          sampleIds: ['m5dea7728fd91c8:1665992993880', 'n1235dea74asdas1:1665992993880'],
-          sampleType: 'trace',
-          sampleSize: '100',
-          failureCount: '70'
-        }
-      ]
-    },
-    {
-      name: 'Noise',
-      score: 90.0,
-      description: 'Trace noise refers to the quality of the existing metadata in spans/traces.',
-      heuristicScoreInfo: [
-        {
-          description: 'Single paragraph description for this heuristic.',
-          name: 'HasNoTokens',
-          evalTimestamp: '1658434128',
-          score: 90.0,
-          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
-          sampleType: 'span',
-          sampleSize: '100',
-          failureCount: '10'
-        },
-        {
-          description: 'Single paragraph description for this heuristic.',
-          name: 'SecondHeuristic',
-          evalTimestamp: '1658434128',
-          score: -1.0,
-          sampleIds: ['m5dea7728fd91c7:1665992993880', 'n1235dea74asdas1:1665992993880'],
-          sampleType: 'span',
-          sampleSize: '100',
-          failureCount: '90'
+          failureCount: '1'
         }
       ]
     }

--- a/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.fixture.ts
+++ b/projects/observability/src/pages/apis/service-detail/instrumentation/service-instrumentation.fixture.ts
@@ -50,7 +50,6 @@ export const serviceScoreResponse: ServiceScoreResponse = {
     },
     {
       name: 'Security',
-      score: 100.0,
       description: 'Trace security refers to the quality of the existing metadata in spans/traces.',
       heuristicScoreInfo: [
         {
@@ -73,7 +72,8 @@ export const serviceScoreResponse: ServiceScoreResponse = {
           sampleSize: '100',
           failureCount: '1'
         }
-      ]
+      ],
+      score: 99.87
     }
   ],
   aggregatedWeightedScore: 60.5


### PR DESCRIPTION
## Description

[Jira][1] | [Slack][2]

We want to show the whole heuristic as failed on the UI if even 1 span fails. Only applicable to Security category.

Made the following changes to Security category:
- There are only 2 heuristic icons: success (for score 100.0) and failure (less than 100).
- Checks summary on cards considers heuristic as failed if 1 span failed.

Change to all categories:
- Scores in category cards will be rounded-down instead of earlier approach of "nearest round". So 99.99 score will be displayed as 99.

## Screenshots

For Security score: 99.87
Heuristics:
- PCI: 100.0
- PII: 99.99

<img width="370" alt="Screenshot 2022-11-14 at 9 59 59 AM" src="https://user-images.githubusercontent.com/29686866/201575552-dda826ea-8899-4ab3-8ea5-0681f3f6c036.png">

<img width="975" alt="Screenshot 2022-11-14 at 10 03 01 AM" src="https://user-images.githubusercontent.com/29686866/201575884-c19bfd59-3c49-420d-9f1b-a8a77e1f731a.png">

### Testing
[Test environment][3]

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

[1]: https://razorpay.atlassian.net/browse/OBSV-1114
[2]: https://razorpay.slack.com/archives/CU5GKS8MQ/p1667459259363039
[3]: https://hypertrace-test.concierge.stage.razorpay.in/services/service/a17bbf63-4751-38f8-9c79-afa3036a0861/instrumentation
