### PR TITLE
feat: set seconds & milliseconds to zero

### DIFF
--- a/projects/common/src/time/relative-time-range.test.ts
+++ b/projects/common/src/time/relative-time-range.test.ts
@@ -1,0 +1,14 @@
+import { RelativeTimeRange } from './relative-time-range';
+import { TimeDuration } from './time-duration';
+import { TimeUnit } from './time-unit.type';
+
+describe('RelativeTimeRange', () => {
+  let component = new RelativeTimeRange(new TimeDuration(1, TimeUnit.Hour));
+
+  test('sets seconds & milliseconds to zero by default', () => {
+    expect(component.startTime.getSeconds()).toBe(0);
+    expect(component.startTime.getMilliseconds()).toBe(0);
+    expect(component.endTime.getSeconds()).toBe(0);
+    expect(component.endTime.getMilliseconds()).toBe(0);
+  });
+});

--- a/projects/common/src/time/relative-time-range.test.ts
+++ b/projects/common/src/time/relative-time-range.test.ts
@@ -3,7 +3,7 @@ import { TimeDuration } from './time-duration';
 import { TimeUnit } from './time-unit.type';
 
 describe('RelativeTimeRange', () => {
-  let component = new RelativeTimeRange(new TimeDuration(1, TimeUnit.Hour));
+  const component = new RelativeTimeRange(new TimeDuration(1, TimeUnit.Hour));
 
   test('sets seconds & milliseconds to zero by default', () => {
     expect(component.startTime.getSeconds()).toBe(0);

--- a/projects/common/src/time/relative-time-range.ts
+++ b/projects/common/src/time/relative-time-range.ts
@@ -5,12 +5,21 @@ export class RelativeTimeRange implements TimeRange {
   public readonly startTime: Date = new Date();
   public readonly endTime: Date = new Date();
 
-  public constructor(public readonly duration: Readonly<TimeDuration>) {
+  public constructor(
+    public readonly duration: Readonly<TimeDuration>,
+    /**
+     * We set seconds and milliseconds to zero in the GraphQL
+     * call for faster processing of the query in the backend
+     */
+    private readonly shouldSetSecondsToZero: boolean = true
+  ) {
     this.endTime.setTime(Date.now());
     this.startTime.setTime(this.endTime.getTime() - this.duration.toMillis());
 
-    this.endTime.setSeconds(0, 0);
-    this.startTime.setSeconds(0, 0);
+    if (this.shouldSetSecondsToZero) {
+      this.endTime.setSeconds(0, 0);
+      this.startTime.setSeconds(0, 0);
+    }
   }
 
   public isCustom(): boolean {

--- a/projects/common/src/time/relative-time-range.ts
+++ b/projects/common/src/time/relative-time-range.ts
@@ -8,6 +8,9 @@ export class RelativeTimeRange implements TimeRange {
   public constructor(public readonly duration: Readonly<TimeDuration>) {
     this.endTime.setTime(Date.now());
     this.startTime.setTime(this.endTime.getTime() - this.duration.toMillis());
+
+    this.endTime.setSeconds(0, 0);
+    this.startTime.setSeconds(0, 0);
   }
 
   public isCustom(): boolean {

--- a/projects/components/src/time-range/time-range.component.test.ts
+++ b/projects/components/src/time-range/time-range.component.test.ts
@@ -150,4 +150,17 @@ describe('Time range component', () => {
     expect(refreshButton.label).toBe('Refresh - updated 6m ago');
     discardPeriodicTasks();
   }));
+
+  test('should set seconds and milliseconds to zero', () => {
+    const spectator = createComponent();
+    const startTime = new Date(2022, 10, 23, 9, 54, 10, 200);
+    const endTime = new Date(2022, 10, 23, 10, 54, 20, 300);
+    spectator.click('.trigger');
+    spectator.component.setToFixedTimeRange(new FixedTimeRange(startTime, endTime));
+
+    expect(startTime.getSeconds()).toBe(0);
+    expect(startTime.getMilliseconds()).toBe(0);
+    expect(endTime.getSeconds()).toBe(0);
+    expect(endTime.getMilliseconds()).toBe(0);
+  });
 });

--- a/projects/components/src/time-range/time-range.component.ts
+++ b/projects/components/src/time-range/time-range.component.ts
@@ -108,6 +108,8 @@ export class TimeRangeComponent {
   }
 
   public setToFixedTimeRange(timeRange: FixedTimeRange): void {
+    timeRange.startTime.setSeconds(0, 0);
+    timeRange.endTime.setSeconds(0, 0);
     this.timeRangeSelected.emit(timeRange);
     this.timeRangeService.setFixedRange(timeRange.startTime, timeRange.endTime);
     this.popoverRef!.close();

--- a/projects/components/src/time-range/time-range.component.ts
+++ b/projects/components/src/time-range/time-range.component.ts
@@ -108,8 +108,13 @@ export class TimeRangeComponent {
   }
 
   public setToFixedTimeRange(timeRange: FixedTimeRange): void {
+    /*
+     * We set seconds and milliseconds to zero in the GraphQL
+     * call for faster processing of the query in the backend
+     */
     timeRange.startTime.setSeconds(0, 0);
     timeRange.endTime.setSeconds(0, 0);
+
     this.timeRangeSelected.emit(timeRange);
     this.timeRangeService.setFixedRange(timeRange.startTime, timeRange.endTime);
     this.popoverRef!.close();


### PR DESCRIPTION
## Description

[Jira][1]

Set both seconds and milliseconds to zero before making the GraphQL call for all queries. 
This is a perf improvement requested by backend.

### Testing

Tested on [test environment][2]

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

[1]: https://razorpay.atlassian.net/browse/OBSV-1145
[2]: https://hypertrace-test.concierge.stage.razorpay.in/services?time=5m