### PR TITLE
feat: display series name with aggregation in explorer chart

### DIFF
--- a/projects/observability/src/shared/graphql/model/metrics/metric-aggregation.ts
+++ b/projects/observability/src/shared/graphql/model/metrics/metric-aggregation.ts
@@ -94,7 +94,6 @@ export const addAggregationToDisplayName = (displayName: string, aggregation: Me
     case MetricAggregationType.P95:
     case MetricAggregationType.P90:
     case MetricAggregationType.P50:
-      return `${displayName} ${getAggregationDisplayName(aggregation)}`;
     case MetricAggregationType.Min:
     case MetricAggregationType.Max:
     case MetricAggregationType.Sum: // Prefix aggregation

--- a/projects/observability/src/shared/graphql/model/metrics/metric-aggregation.ts
+++ b/projects/observability/src/shared/graphql/model/metrics/metric-aggregation.ts
@@ -94,7 +94,7 @@ export const addAggregationToDisplayName = (displayName: string, aggregation: Me
     case MetricAggregationType.P95:
     case MetricAggregationType.P90:
     case MetricAggregationType.P50:
-      return displayName;
+      return `${displayName} ${getAggregationDisplayName(aggregation)}`;
     case MetricAggregationType.Min:
     case MetricAggregationType.Max:
     case MetricAggregationType.Sum: // Prefix aggregation


### PR DESCRIPTION
## Description
Display series `name` along with its `aggregation` to differentiate between multiline series in Explorer Dashboard.
Screenshot:
<img width="1512" alt="Screenshot 2022-12-06 at 4 48 07 PM" src="https://user-images.githubusercontent.com/45780866/205897600-9143461f-597a-4582-b0fc-300b044f0c67.png">

### Testing
Tested on local

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

