### PR TITLE
Adds `refresh` button for Fixed Time Range (custom time range)

### DIFF
--- a/projects/common/src/time/time-range.service.test.ts
+++ b/projects/common/src/time/time-range.service.test.ts
@@ -7,6 +7,8 @@ import { NavigationService, QueryParamObject } from '../navigation/navigation.se
 import { FixedTimeRange } from './fixed-time-range';
 import { TimeRangeService } from './time-range.service';
 
+import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
+
 describe('Time range(TR) service', () => {
   let timeRange$: Observable<string> = NEVER;
   const buildService = createServiceFactory({
@@ -31,7 +33,14 @@ describe('Time range(TR) service', () => {
           .mockReturnValue('1573255111159-1573455111990'),
         getCurrentActivatedRoute: () =>
           (({ snapshot: { queryParams: { time: 'test-value' } } } as unknown) as ActivatedRoute)
-      })
+      }),
+      {
+        provide: GRAPHQL_OPTIONS,
+        useValue: {
+          uri: '/graphql',
+          batchSize: 2
+        }
+      }
     ]
   });
 
@@ -84,7 +93,14 @@ describe('Time range(TR) service', () => {
               .mockReturnValue(secondArrivingTimeRange.toUrlString()),
             getCurrentActivatedRoute: () =>
               (({ snapshot: { queryParams: { time: 'test-value' } } } as unknown) as ActivatedRoute)
-          })
+          }),
+          {
+            provide: GRAPHQL_OPTIONS,
+            useValue: {
+              uri: '/graphql',
+              batchSize: 2
+            }
+          }
         ]
       });
 
@@ -128,7 +144,14 @@ describe('Time range(TR) service', () => {
             getCurrentActivatedRoute: () =>
               (({ snapshot: { queryParams: { time: 'test-value' } } } as unknown) as ActivatedRoute),
             replaceQueryParametersInUrl: jest.fn()
-          })
+          }),
+          {
+            provide: GRAPHQL_OPTIONS,
+            useValue: {
+              uri: '/graphql',
+              batchSize: 2
+            }
+          }
         ]
       });
 

--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ParamMap } from '@angular/router';
+import { GraphQlRequestService } from '@hypertrace/graphql-client';
 import { isEmpty, isNil, omit } from 'lodash-es';
 import { concat, EMPTY, Observable, ReplaySubject } from 'rxjs';
 import { catchError, distinctUntilChanged, filter, map, switchMap, take } from 'rxjs/operators';
@@ -24,7 +25,8 @@ export class TimeRangeService {
 
   public constructor(
     private readonly navigationService: NavigationService,
-    private readonly timeDurationService: TimeDurationService
+    private readonly timeDurationService: TimeDurationService,
+    private readonly graphQLService: GraphQlRequestService
   ) {
     this.initializeTimeRange();
     this.navigationService.registerGlobalQueryParamKey(TimeRangeService.TIME_RANGE_QUERY_PARAM);
@@ -50,6 +52,12 @@ export class TimeRangeService {
     }
 
     return this.currentTimeRange;
+  }
+
+  // This is needed for custom time range
+  // We need to reset the cache before firing the same query again.
+  public clearCache(): void {
+    this.graphQLService.clearCache();
   }
 
   public setRelativeRange(value: number, unit: TimeUnit): this {

--- a/projects/components/src/navigation/nav-item/nav-item.component.test.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.test.ts
@@ -8,8 +8,8 @@ import {
   NavigationService
 } from '@hypertrace/common';
 import { BetaTagComponent, IconComponent, LinkComponent } from '@hypertrace/components';
-import { createHostFactory, mockProvider, SpectatorHost } from '@ngneat/spectator/jest';
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
+import { createHostFactory, mockProvider, SpectatorHost } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
 import { NavItemConfig, NavItemType } from '../navigation.config';

--- a/projects/components/src/navigation/nav-item/nav-item.component.test.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@hypertrace/common';
 import { BetaTagComponent, IconComponent, LinkComponent } from '@hypertrace/components';
 import { createHostFactory, mockProvider, SpectatorHost } from '@ngneat/spectator/jest';
+import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { MockComponent } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
 import { NavItemConfig, NavItemType } from '../navigation.config';
@@ -35,7 +36,14 @@ describe('Navigation Item Component', () => {
       mockProvider(FeatureStateResolver, {
         getCombinedFeatureState: () => of(FeatureState.Enabled),
         getFeatureState: () => of(FeatureState.Enabled)
-      })
+      }),
+      {
+        provide: GRAPHQL_OPTIONS,
+        useValue: {
+          uri: '/graphql',
+          batchSize: 2
+        }
+      }
     ]
   });
 

--- a/projects/components/src/time-range/time-range.component.test.ts
+++ b/projects/components/src/time-range/time-range.component.test.ts
@@ -108,7 +108,7 @@ describe('Time range component', () => {
     expect(spectator.query('.refresh')).toExist();
   });
 
-  test('should not show refresh button when time range is fixed', () => {
+  test('should show refresh button when time range is fixed', () => {
     const spectator = createComponent({
       providers: [
         mockProvider(TimeRangeService, {
@@ -126,7 +126,7 @@ describe('Time range component', () => {
     expect(spectator.query('.custom-time-range-selection', { root: true })).not.toExist();
 
     spectator.click(spectator.queryAll('.popover-item', { root: true })[1]);
-    expect(spectator.query('.refresh')).not.toExist();
+    expect(spectator.query('.refresh')).toExist();
   });
 
   test('should publish new time range when refresh is clicked', () => {

--- a/projects/components/src/time-range/time-range.component.ts
+++ b/projects/components/src/time-range/time-range.component.ts
@@ -127,7 +127,7 @@ export class TimeRangeComponent {
   public getRefreshButtonData = (timeRange: TimeRange): Observable<RefreshButtonData> => {
     const lastRefreshTimeMillis = Date.now();
 
-    const defaultRefreshObservable: Observable<RefreshButtonData> = of({
+    const defaultRefresh$: Observable<RefreshButtonData> = of({
       text$: of('Refresh'),
       role: ButtonRole.Tertiary,
       isEmphasized: false,

--- a/projects/components/src/time-range/time-range.component.ts
+++ b/projects/components/src/time-range/time-range.component.ts
@@ -8,7 +8,7 @@ import {
   TimeRangeService,
   TimeUnit
 } from '@hypertrace/common';
-import { concat, EMPTY, interval, Observable, of, timer } from 'rxjs';
+import { concat, interval, Observable, of, timer } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { ButtonRole, ButtonSize } from '../button/button';
 import { IconSize } from '../icon/icon-size';
@@ -126,14 +126,19 @@ export class TimeRangeComponent {
 
   public getRefreshButtonData = (timeRange: TimeRange): Observable<RefreshButtonData> => {
     const lastRefreshTimeMillis = Date.now();
+
+    const defaultRefreshObservable: Observable<RefreshButtonData> = of({
+      text$: of('Refresh'),
+      role: ButtonRole.Tertiary,
+      isEmphasized: false,
+      onClick: () => this.onRefresh()
+    });
+
+    // In case of relative time range, we give refresh button for manual prompt
+    // We also keep a timer to tell elapsed time and prompt user to refresh
     if (this.isRelative(timeRange)) {
       return concat(
-        of({
-          text$: of('Refresh'),
-          role: ButtonRole.Tertiary,
-          isEmphasized: false,
-          onClick: () => this.onRefresh()
-        }),
+        defaultRefreshObservable,
         this.ngZone.runOutsideAngular(() =>
           // Long running timer will prevent zone from stabilizing
           timer(this.refreshDuration.toMillis()).pipe(
@@ -157,7 +162,10 @@ export class TimeRangeComponent {
       );
     }
 
-    return EMPTY;
+    // This is to ensure that in case of timeouts, we again query the backend rather than returning error from cache
+    this.timeRangeService.clearCache();
+
+    return defaultRefreshObservable;
   };
 
   private onRefresh(): void {

--- a/projects/components/src/time-range/time-range.component.ts
+++ b/projects/components/src/time-range/time-range.component.ts
@@ -138,7 +138,7 @@ export class TimeRangeComponent {
     // We also keep a timer to tell elapsed time and prompt user to refresh
     if (this.isRelative(timeRange)) {
       return concat(
-        defaultRefreshObservable,
+        defaultRefresh$,
         this.ngZone.runOutsideAngular(() =>
           // Long running timer will prevent zone from stabilizing
           timer(this.refreshDuration.toMillis()).pipe(
@@ -165,7 +165,7 @@ export class TimeRangeComponent {
     // This is to ensure that in case of timeouts, we again query the backend rather than returning error from cache
     this.timeRangeService.clearCache();
 
-    return defaultRefreshObservable;
+    return defaultRefresh$;
   };
 
   private onRefresh(): void {

--- a/projects/graphql-client/src/graphql-request.service.ts
+++ b/projects/graphql-client/src/graphql-request.service.ts
@@ -85,6 +85,11 @@ export class GraphQlRequestService {
     }
   }
 
+  // Needs to be called when some service calls error out and we want to refetch data
+  public clearCache(): void {
+    this.apollo.client.clearStore();
+  }
+
   private fireRequests(...requests: RequestWithOptions[]): Map<GraphQlRequest, Observable<GraphQlResult>> {
     const requestTypeMap = this.groupQueriesByRequestType(requests);
 

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.test.ts
@@ -10,6 +10,7 @@ import {
   TimeUnit
 } from '@hypertrace/common';
 import { patchRouterNavigateForTest, recordObservable, runFakeRxjs } from '@hypertrace/test-utils';
+import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { MetricAggregationType } from '../../graphql/model/metrics/metric-aggregation';
@@ -38,7 +39,14 @@ describe('Explore visualization builder', () => {
       }),
       mockProvider(FeatureStateResolver, {
         getFeatureState: () => of(FeatureState.Enabled)
-      })
+      }),
+      {
+        provide: GRAPHQL_OPTIONS,
+        useValue: {
+          uri: '/graphql',
+          batchSize: 2
+        }
+      }
     ]
   });
 

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.test.ts
@@ -9,8 +9,8 @@ import {
   TimeRangeService,
   TimeUnit
 } from '@hypertrace/common';
-import { patchRouterNavigateForTest, recordObservable, runFakeRxjs } from '@hypertrace/test-utils';
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
+import { patchRouterNavigateForTest, recordObservable, runFakeRxjs } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { MetricAggregationType } from '../../graphql/model/metrics/metric-aggregation';


### PR DESCRIPTION
- Show the `refresh` button even when a static time range is applied.
  - Manually resets the `cache` so that previous results (inclusive of `error`) are not returned from the `cache`.