### PR TITLE
[OBSV-939] Adds support for client side filtering in Entity Tables

### DIFF
--- a/projects/components/src/table/data/table-data-source.ts
+++ b/projects/components/src/table/data/table-data-source.ts
@@ -15,6 +15,8 @@ export interface TableDataRequest<TCol extends TableColumnConfig = TableColumnCo
   sort?: SortSpecification<TCol>;
   filters?: TableFilter[];
   includeInactive?: boolean;
+
+  // New properties solely added for client side filtering specifications
   clientSideFilters?: TableFilter[];
   clientSideSort?: SortSpecification<TCol>;
 }
@@ -29,6 +31,7 @@ export interface SortSpecification<T> {
   direction: TableSortDirection;
 }
 
+// We need this information in the data source layer as the query needs to be reset to the original one to prevent refetch
 export interface ClientSideSort {
   direction: TableSortDirection;
   defaultSortColumnIndex: number;

--- a/projects/components/src/table/data/table-data-source.ts
+++ b/projects/components/src/table/data/table-data-source.ts
@@ -12,15 +12,24 @@ export interface TableDataRequest<TCol extends TableColumnConfig = TableColumnCo
     startIndex: number;
     limit: number;
   };
-  sort?: {
-    column: TCol;
-    direction: TableSortDirection;
-  };
+  sort?: SortSpecification<TCol>;
   filters?: TableFilter[];
   includeInactive?: boolean;
+  clientSideFilters?: TableFilter[];
+  clientSideSort?: SortSpecification<TCol>;
 }
 
 export interface TableDataResponse<TData> {
   data: TData[];
   totalCount: number;
+}
+
+export interface SortSpecification<T> {
+  column: T;
+  direction: TableSortDirection;
+}
+
+export interface ClientSideSort {
+  direction: TableSortDirection;
+  defaultSortColumnIndex: number;
 }

--- a/projects/components/src/table/data/table-data-source.ts
+++ b/projects/components/src/table/data/table-data-source.ts
@@ -16,8 +16,13 @@ export interface TableDataRequest<TCol extends TableColumnConfig = TableColumnCo
   filters?: TableFilter[];
   includeInactive?: boolean;
 
-  // New properties solely added for client side filtering specifications
+  /**
+   * New property solely added for client side filtering specifications
+   */
   clientSideFilters?: TableFilter[];
+  /**
+   * New property solely added for client side sorting specifications
+   */
   clientSideSort?: SortSpecification<TCol>;
 }
 
@@ -31,7 +36,10 @@ export interface SortSpecification<T> {
   direction: TableSortDirection;
 }
 
-// We need this information in the data source layer as the query needs to be reset to the original one to prevent refetch
+/**
+ * We need this information in the data source layer as the query
+ * needs to be reset to the original one to prevent refetch
+ */
 export interface ClientSideSort {
   direction: TableSortDirection;
   defaultSortColumnIndex: number;

--- a/projects/observability/src/pages/apis/backends/backend-list.component.ts
+++ b/projects/observability/src/pages/apis/backends/backend-list.component.ts
@@ -27,6 +27,7 @@ export class BackendListComponent {
         title: 'Name',
         display: ObservabilityTableCellType.Entity,
         width: '30%',
+        pageable: false,
         value: {
           type: 'entity-specification',
           'entity-type': ObservabilityEntityType.Backend
@@ -106,7 +107,13 @@ export class BackendListComponent {
     ],
     data: {
       type: 'entity-table-data-source',
-      entity: 'BACKEND'
+      entity: 'BACKEND',
+      isClientSideRendered: true,
+      limit: 300,
+      clientSideSort: {
+        direction: TableSortDirection.Descending,
+        defaultSortColumnIndex: 0
+      }
     }
   };
 }

--- a/projects/observability/src/pages/apis/backends/backend-list.component.ts
+++ b/projects/observability/src/pages/apis/backends/backend-list.component.ts
@@ -109,7 +109,7 @@ export class BackendListComponent {
     data: {
       type: 'entity-table-data-source',
       entity: 'BACKEND',
-      isClientSideRendered: true,
+      isClientSideFiltered: true,
       limit: 300,
       clientSideSort: {
         direction: TableSortDirection.Descending,

--- a/projects/observability/src/pages/apis/backends/backend-list.component.ts
+++ b/projects/observability/src/pages/apis/backends/backend-list.component.ts
@@ -21,13 +21,13 @@ export class BackendListComponent {
     id: 'backends-list.table',
     style: TableStyle.FullPage,
     searchAttribute: 'name',
+    pageable: false,
     columns: [
       {
         type: 'table-widget-column',
         title: 'Name',
         display: ObservabilityTableCellType.Entity,
         width: '30%',
-        pageable: false,
         value: {
           type: 'entity-specification',
           'entity-type': ObservabilityEntityType.Backend
@@ -42,7 +42,8 @@ export class BackendListComponent {
         value: {
           type: 'attribute-specification',
           attribute: 'type'
-        }
+        },
+        sortable: false
       },
       {
         type: 'table-widget-column',

--- a/projects/observability/src/pages/apis/services/service-list.dashboard.ts
+++ b/projects/observability/src/pages/apis/services/service-list.dashboard.ts
@@ -94,7 +94,7 @@ export const serviceListDashboard: DashboardDefaultConfiguration = {
         data: {
           type: 'entity-table-data-source',
           entity: 'SERVICE',
-          isClientSideRendered: true,
+          isClientSideFiltered: true,
           limit: 250,
           clientSideSort: {
             direction: TableSortDirection.Descending,

--- a/projects/observability/src/pages/apis/services/service-list.dashboard.ts
+++ b/projects/observability/src/pages/apis/services/service-list.dashboard.ts
@@ -18,6 +18,7 @@ export const serviceListDashboard: DashboardDefaultConfiguration = {
         mode: TableMode.Flat,
         style: TableStyle.FullPage,
         searchAttribute: 'name',
+        pageable: false,
         columns: [
           {
             type: 'table-widget-column',
@@ -92,7 +93,13 @@ export const serviceListDashboard: DashboardDefaultConfiguration = {
         ],
         data: {
           type: 'entity-table-data-source',
-          entity: 'SERVICE'
+          entity: 'SERVICE',
+          isClientSideRendered: true,
+          limit: 250,
+          clientSideSort: {
+            direction: TableSortDirection.Descending,
+            defaultSortColumnIndex: 0
+          }
         }
       }
     ]

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
@@ -1,4 +1,11 @@
-import { TableDataRequest, TableDataResponse, TableRow } from '@hypertrace/components';
+import {
+  FilterOperator,
+  TableDataRequest,
+  TableDataResponse,
+  TableFilter,
+  TableRow,
+  TableSortDirection
+} from '@hypertrace/components';
 import {
   ARRAY_PROPERTY,
   Model,
@@ -9,9 +16,11 @@ import {
 } from '@hypertrace/hyperdash';
 import { EMPTY, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { isMetricAggregation, MetricAggregation } from '../../../../../graphql/model/metrics/metric-aggregation';
 import { Entity, EntityType } from '../../../../../graphql/model/schema/entity';
 import { GraphQlEntityFilter } from '../../../../../graphql/model/schema/filter/entity/graphql-entity-filter';
 import { GraphQlFilter } from '../../../../../graphql/model/schema/filter/graphql-filter';
+import { EntitySpecification } from '../../../../../graphql/model/schema/specifications/entity-specification';
 import { Specification } from '../../../../../graphql/model/schema/specifier/specification';
 import { EntitiesResponse } from '../../../../../graphql/request/handlers/entities/query/entities-graphql-query-builder.service';
 import {
@@ -59,17 +68,38 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
     filters: GraphQlFilter[],
     request: TableDataRequest<SpecificationBackedTableColumnDef>
   ): GraphQlEntitiesQueryRequest {
+    // tslint:disable-next-line: strict-boolean-expressions
+    if (this.isClientSideRendered) {
+      request.clientSideFilters = request.filters;
+      if (request.sort !== undefined) {
+        request.clientSideSort = {
+          direction: request.sort.direction,
+          column: request.sort.column
+        };
+      }
+    }
+    const offset = this.isClientSideRendered ? 0 : request.position.startIndex;
+
+    let sort = request.sort && {
+      direction: request.sort.direction,
+      key: request.sort.column.specification
+    };
+
+    if (this.isClientSideRendered && this.clientSideSort !== undefined) {
+      sort = {
+        direction: this.clientSideSort.direction,
+        key: request.columns[this.clientSideSort.defaultSortColumnIndex].specification
+      };
+    }
+
     return {
       requestType: ENTITIES_GQL_REQUEST,
       entityType: this.entityType,
       properties: request.columns.map(column => column.specification).concat(...this.additionalSpecifications),
-      limit: this.limit !== undefined ? this.limit : request.position.limit * 2, // Prefetch 2 pages
-      offset: request.position.startIndex,
-      sort: request.sort && {
-        direction: request.sort.direction,
-        key: request.sort.column.specification
-      },
-      filters: [...filters, ...this.toGraphQlFilters(request.filters)],
+      limit: this.limit ?? request.position.limit * 2, // Prefetch 2 pages,
+      offset: offset,
+      sort: sort,
+      filters: this.isClientSideRendered ? [] : [...filters, ...this.toGraphQlFilters(request.filters)],
       timeRange: this.getTimeRangeOrThrow(),
       includeTotal: true,
       includeInactive: request.includeInactive
@@ -80,10 +110,93 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
     response: EntitiesResponse,
     request: TableDataRequest<SpecificationBackedTableColumnDef>
   ): TableDataResponse<TableRow> {
+    let results: Entity<string>[] = response.results;
+    if (
+      this.isClientSideRendered &&
+      request.clientSideFilters?.length !== undefined &&
+      request.clientSideFilters.length > 0
+    ) {
+      request.clientSideFilters.forEach(clientSideFilter => {
+        const matchingColumn = this.findMatchingColumnConfigForClientSideFilter(
+          clientSideFilter.field,
+          request.columns
+        );
+        if (matchingColumn !== undefined) {
+          results = this.filterRespValuesForClientSideFilter(matchingColumn, results, clientSideFilter);
+        }
+      });
+    }
+
+    if (request.clientSideSort !== undefined && this.isClientSideRendered && results.length > 0) {
+      if (isMetricAggregation(results[0][request.clientSideSort.column.id])) {
+        results.sort((res1, res2) => {
+          if (request.clientSideSort!.direction === TableSortDirection.Ascending) {
+            return (
+              (res1[request.clientSideSort!.column.id] as MetricAggregation).value -
+              (res2[request.clientSideSort!.column.id] as MetricAggregation).value
+            );
+          }
+
+          return (
+            (res2[request.clientSideSort!.column.id] as MetricAggregation).value -
+            (res1[request.clientSideSort!.column.id] as MetricAggregation).value
+          );
+        });
+      } else {
+        results.sort((res1, res2) => {
+          if (request.clientSideSort!.direction === TableSortDirection.Ascending) {
+            return ((res1[request.clientSideSort!.column.id] as Entity).name as string).localeCompare(
+              (res2[request.clientSideSort!.column.id] as Entity).name as string
+            );
+          }
+
+          return ((res2[request.clientSideSort!.column.id] as Entity).name as string).localeCompare(
+            (res1[request.clientSideSort!.column.id] as Entity).name as string
+          );
+        });
+      }
+    }
+
     return {
-      data: this.resultsAsTreeRows(response.results, request, this.childEntityDataSource !== undefined),
-      totalCount: response.total!
+      data: this.resultsAsTreeRows(results, request, this.childEntityDataSource !== undefined),
+      totalCount: this.isClientSideRendered ? results.length : response.total ?? 0
     };
+  }
+
+  private findMatchingColumnConfigForClientSideFilter(
+    filterKeyName: string,
+    columnDefs: SpecificationBackedTableColumnDef[]
+  ): SpecificationBackedTableColumnDef | undefined {
+    return columnDefs.find(
+      maybeColumn =>
+        (maybeColumn.specification as EntitySpecification).asGraphQlOrderByFragment().expression.key === filterKeyName
+    );
+  }
+
+  private filterRespValuesForClientSideFilter(
+    columnDef: SpecificationBackedTableColumnDef,
+    rows: Entity[],
+    tableFilter: TableFilter
+  ): Entity<string>[] {
+    const actualKeyNameInRows = columnDef.specification.resultAlias();
+    // tslint:disable-next-line: prefer-switch
+    if (tableFilter.operator === FilterOperator.Equals) {
+      return rows.filter(eachRow => ((eachRow[actualKeyNameInRows] as Entity).name as string) === tableFilter.value);
+    }
+
+    if (tableFilter.operator === FilterOperator.Like) {
+      const regexExp = new RegExp(tableFilter.value as string);
+
+      return rows.filter(eachRow => regexExp.test((eachRow[actualKeyNameInRows] as Entity).name as string));
+    }
+
+    if (tableFilter.operator === FilterOperator.In) {
+      return rows.filter(eachRow =>
+        (tableFilter.value as string[]).includes((eachRow[actualKeyNameInRows] as Entity).name as string)
+      );
+    }
+
+    return rows;
   }
 
   private resultsAsTreeRows(

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
@@ -179,24 +179,20 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
     tableFilter: TableFilter
   ): Entity<string>[] {
     const actualKeyNameInRows = columnDef.specification.resultAlias();
-    // tslint:disable-next-line: prefer-switch
-    if (tableFilter.operator === FilterOperator.Equals) {
-      return rows.filter(eachRow => ((eachRow[actualKeyNameInRows] as Entity).name as string) === tableFilter.value);
+
+    switch (tableFilter.operator) {
+      case FilterOperator.Equals:
+        return rows.filter(eachRow => ((eachRow[actualKeyNameInRows] as Entity).name as string) === tableFilter.value);
+      case FilterOperator.Like:
+        const regexExp = new RegExp(tableFilter.value as string);
+        return rows.filter(eachRow => regexExp.test((eachRow[actualKeyNameInRows] as Entity).name as string));
+      case FilterOperator.In:
+        return rows.filter(eachRow =>
+          (tableFilter.value as string[]).includes((eachRow[actualKeyNameInRows] as Entity).name as string)
+        );
+      default:
+        return rows;
     }
-
-    if (tableFilter.operator === FilterOperator.Like) {
-      const regexExp = new RegExp(tableFilter.value as string);
-
-      return rows.filter(eachRow => regexExp.test((eachRow[actualKeyNameInRows] as Entity).name as string));
-    }
-
-    if (tableFilter.operator === FilterOperator.In) {
-      return rows.filter(eachRow =>
-        (tableFilter.value as string[]).includes((eachRow[actualKeyNameInRows] as Entity).name as string)
-      );
-    }
-
-    return rows;
   }
 
   private resultsAsTreeRows(

--- a/projects/observability/src/shared/dashboard/data/graphql/table/table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/table-data-source.model.ts
@@ -28,11 +28,11 @@ export abstract class TableDataSourceModel extends GraphQlDataSourceModel<TableD
   public limit?: number;
 
   @ModelProperty({
-    key: 'isClientSideRendered',
-    displayName: 'Client Side Rendered',
+    key: 'isClientSideFiltered',
+    displayName: 'Client Side Filtered',
     type: BOOLEAN_PROPERTY.type
   })
-  public isClientSideRendered?: boolean;
+  public isClientSideFiltered?: boolean;
 
   @ModelProperty({
     key: 'clientSideSort',

--- a/projects/observability/src/shared/dashboard/data/graphql/table/table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/table-data-source.model.ts
@@ -1,6 +1,13 @@
-import { TableDataRequest, TableDataResponse, TableDataSource, TableFilter, TableRow } from '@hypertrace/components';
+import {
+  ClientSideSort,
+  TableDataRequest,
+  TableDataResponse,
+  TableDataSource,
+  TableFilter,
+  TableRow
+} from '@hypertrace/components';
 import { GraphQlRequestOptions } from '@hypertrace/graphql-client';
-import { ModelProperty, NUMBER_PROPERTY } from '@hypertrace/hyperdash';
+import { BOOLEAN_PROPERTY, ModelProperty, NUMBER_PROPERTY, UNKNOWN_PROPERTY } from '@hypertrace/hyperdash';
 import { ModelInject } from '@hypertrace/hyperdash-angular';
 import { Observable, of as observableOf } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -19,6 +26,20 @@ export abstract class TableDataSourceModel extends GraphQlDataSourceModel<TableD
     type: NUMBER_PROPERTY.type
   })
   public limit?: number;
+
+  @ModelProperty({
+    key: 'isClientSideRendered',
+    displayName: 'Client Side Rendered',
+    type: BOOLEAN_PROPERTY.type
+  })
+  public isClientSideRendered?: boolean;
+
+  @ModelProperty({
+    key: 'clientSideSort',
+    displayName: 'Client Side Sort',
+    type: UNKNOWN_PROPERTY.type
+  })
+  public clientSideSort?: ClientSideSort;
 
   public getData(): Observable<TableDataSource<TableRow, SpecificationBackedTableColumnDef>> {
     return observableOf({


### PR DESCRIPTION
## Description
- Adds the support for client side filtering for the entity tables in HyperTrace (Services, Backends, Endpoints)
  - Currently supported filters on UI are `IN`, `LIKE` and `EQUALS`, more filters can be built upon in the future as and when the need arises, the code is generic enough for more filter based functions to be added.
  - `limit` parameter is `optional` in the graphQL schema, but not sending it gives erratic behavior, so have added it for now. - Added relevant documentation in the code wherever needed.


[Jira Ticket Link](https://razorpay.atlassian.net/browse/OBSV-939)

### Testing
- Tested changes in local, seem to work fine, currently haven't yet added new unit tests for the use case.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


