### PR TITLE
feat/rudderstack payload changes

### DIFF
--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -71,8 +71,8 @@ export class UserTelemetryImplService extends UserTelemetryService {
       );
   }
 
-  private getDateDiff(timeParamValue: string | null | undefined) {
-    if (timeParamValue) {
+  private getDateDiff(timeParamValue: string | undefined): number | undefined {
+    if (timeParamValue !== undefined) {
       const timeRangeArray = timeParamValue.split('-');
       const startTime = Number(timeRangeArray[0].trim());
       const endDate = new Date();
@@ -80,9 +80,10 @@ export class UserTelemetryImplService extends UserTelemetryService {
       const diffInTime = endDate.getTime() - startTime;
       const diffInDays = diffInTime / (1000 * 3600 * 24);
 
-      return diffInDays.toFixed(0);
+      return Number(diffInDays.toFixed(0));
     }
-    return null;
+
+    return timeParamValue;
   }
 
   private buildTelemetryProvider(config: UserTelemetryRegistrationConfig<unknown>): UserTelemetryInternalConfig {
@@ -103,8 +104,8 @@ export class UserTelemetryImplService extends UserTelemetryService {
       .subscribe(route => {
         const queryParamMap = this.router?.routerState.snapshot.root.queryParamMap;
         // Todo - Read from TimeRangeService.TIME_QUERY_PARAM once root cause for test case failure is identified
-        const timeParamValue = queryParamMap?.get('time');
-        const isCustomTimeSelected = isCustomTime(timeParamValue !== null ? timeParamValue : undefined);
+        const timeParamValue = queryParamMap?.get('time') ?? undefined;
+        const isCustomTimeSelected = isCustomTime(timeParamValue);
         const rootObj = this.router?.parseUrl(route.url).root;
         const urlSegments = rootObj?.children?.primary?.segments.map(segment => segment.path) || [];
         this.trackPageEvent(UserTelemetryEvent.navigate, {

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Injector, Optional } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { delay, filter } from 'rxjs/operators';
-import { getDifferenceInDays } from '../public-api';
+import { getDifferenceInDays } from '../utilities/operations/operation-utilities';
 import { Dictionary } from '../utilities/types/types';
 import { UserTelemetryProvider, UserTelemetryRegistrationConfig, UserTraits } from './telemetry';
 import { UserTelemetryService } from './user-telemetry.service';

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -74,13 +74,13 @@ export class UserTelemetryImplService extends UserTelemetryService {
   private getDifferenceInDays(timeParamValue: string | undefined): number | undefined {
     if (timeParamValue !== undefined) {
       const timeRangeArray = timeParamValue.split('-');
-      const startTime = Number(timeRangeArray[0].trim());
+      const startTimeInMilliseconds = Number(timeRangeArray[0].trim());
       const endDate = new Date();
 
-      const diffInTime = endDate.getTime() - startTime;
-      const diffInDays = diffInTime / (1000 * 3600 * 24);
+      const differenceInMilliseconds = endDate.getTime() - startTimeInMilliseconds;
+      const differenceInDays = differenceInMilliseconds / (1000 * 3600 * 24);
 
-      return Number(diffInDays.toFixed(0));
+      return Number(differenceInDays.toFixed(0));
     }
 
     return timeParamValue;

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Injector, Optional } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { delay, filter } from 'rxjs/operators';
+import { getDifferenceInDays } from '../public-api';
 import { Dictionary } from '../utilities/types/types';
 import { UserTelemetryProvider, UserTelemetryRegistrationConfig, UserTraits } from './telemetry';
 import { UserTelemetryService } from './user-telemetry.service';
@@ -71,21 +72,6 @@ export class UserTelemetryImplService extends UserTelemetryService {
       );
   }
 
-  private getDifferenceInDays(timeParamValue: string | undefined): number | undefined {
-    if (timeParamValue !== undefined) {
-      const timeRangeArray = timeParamValue.split('-');
-      const startTimeInMilliseconds = Number(timeRangeArray[0].trim());
-      const endDate = new Date();
-
-      const differenceInMilliseconds = endDate.getTime() - startTimeInMilliseconds;
-      const differenceInDays = differenceInMilliseconds / (1000 * 3600 * 24);
-
-      return Number(differenceInDays.toFixed(0));
-    }
-
-    return timeParamValue;
-  }
-
   private buildTelemetryProvider(config: UserTelemetryRegistrationConfig<unknown>): UserTelemetryInternalConfig {
     const providerInstance = this.injector.get(config.telemetryProvider);
 
@@ -112,7 +98,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
           url: route.url,
           ...queryParamMap,
           isCustomTime: isCustomTimeSelected,
-          ...(isCustomTimeSelected ? { diffInDays: this.getDifferenceInDays(timeParamValue) } : {}),
+          ...(isCustomTimeSelected ? { diffInDays: getDifferenceInDays(timeParamValue) } : {}),
           urlSegments: urlSegments,
           basePath: urlSegments.length >= 0 ? urlSegments[0] : undefined
         });

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -71,7 +71,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
       );
   }
 
-  private getDateDiff(timeParamValue: string | undefined): number | undefined {
+  private getDifferenceInDays(timeParamValue: string | undefined): number | undefined {
     if (timeParamValue !== undefined) {
       const timeRangeArray = timeParamValue.split('-');
       const startTime = Number(timeRangeArray[0].trim());
@@ -112,7 +112,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
           url: route.url,
           ...queryParamMap,
           isCustomTime: isCustomTimeSelected,
-          ...(isCustomTimeSelected ? { dateDiff: this.getDateDiff(timeParamValue) } : {}),
+          ...(isCustomTimeSelected ? { diffInDays: this.getDifferenceInDays(timeParamValue) } : {}),
           urlSegments: urlSegments,
           basePath: urlSegments.length >= 0 ? urlSegments[0] : undefined
         });

--- a/projects/common/src/user/user-info.service.ts
+++ b/projects/common/src/user/user-info.service.ts
@@ -4,7 +4,7 @@ import { Observable, of } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { LoggerService } from '../logger/logger.service';
 import { UserTraits } from '../telemetry/telemetry';
-import { InMemoryStorage } from '../utilities/browser/storage/in-memory-storage';
+import { LocalStorage } from '../utilities/browser/storage/local-storage';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +15,7 @@ export class UserInfoService {
   public static readonly DEFAULT_USER: UserTraits = { id: 2, name: 'ht-user', email: 'ht-user@razorpay.com' };
   public constructor(
     private readonly http: HttpClient,
-    private readonly inMemoryStorage: InMemoryStorage,
+    private readonly localStorage: LocalStorage,
     private readonly logger: LoggerService
   ) {}
 
@@ -29,19 +29,18 @@ export class UserInfoService {
     return this.http.get<UserTraits>('/user-info').pipe(
       tap((data: UserTraits) => {
         if (data.email !== '') {
-          this.inMemoryStorage.set(UserInfoService.STORAGE_KEY, JSON.stringify(data));
+          this.localStorage.set(UserInfoService.STORAGE_KEY, JSON.stringify(data));
         }
       }),
       catchError(error => {
         this.logger.error('Something went wrong while fetching /user-info', error);
-
         return of({});
       })
     );
   }
 
   public getUserData(): UserTraits {
-    const user = this.inMemoryStorage.get(UserInfoService.STORAGE_KEY);
+    const user = this.localStorage.get(UserInfoService.STORAGE_KEY);
     if (user !== undefined) {
       return JSON.parse(user);
     }

--- a/projects/common/src/user/user-info.service.ts
+++ b/projects/common/src/user/user-info.service.ts
@@ -11,7 +11,7 @@ import { LocalStorage } from '../utilities/browser/storage/local-storage';
 })
 export class UserInfoService {
   public BASE_URL: string = '/user-preferences';
-  public static readonly STORAGE_KEY: 'user-data';
+  public static readonly STORAGE_KEY: string = 'user-data';
   public static readonly DEFAULT_USER: UserTraits = { id: 2, name: 'ht-user', email: 'ht-user@razorpay.com' };
   public constructor(
     private readonly http: HttpClient,
@@ -26,6 +26,13 @@ export class UserInfoService {
       return of({});
     }
 
+    // Check if user info is already present in local storage
+    // Return the value without making the api call
+    const userInfo = this.getUserData();
+    if (userInfo !== UserInfoService.DEFAULT_USER) {
+      return of(userInfo);
+    }
+
     return this.http.get<UserTraits>('/user-info').pipe(
       tap((data: UserTraits) => {
         if (data.email !== '') {
@@ -34,6 +41,7 @@ export class UserInfoService {
       }),
       catchError(error => {
         this.logger.error('Something went wrong while fetching /user-info', error);
+
         return of({});
       })
     );

--- a/projects/common/src/utilities/operations/operation-utilities.test.ts
+++ b/projects/common/src/utilities/operations/operation-utilities.test.ts
@@ -1,0 +1,18 @@
+import { getDifferenceInDays } from './operation-utilities';
+
+describe('get difference in days', () => {
+  it('should return no. of days from start date till current date', () => {
+    const result = getDifferenceInDays('1671069000000-1671159000000');
+    expect(result).toBe(1);
+  });
+
+  it('should return 0 if current date and start date is on the same day', () => {
+    const result = getDifferenceInDays('1671155400000-1671159000000');
+    expect(result).toBe(0);
+  });
+
+  it('should return undefined for null/undefined timeParamValue', () => {
+    const result = getDifferenceInDays(undefined);
+    expect(result).toBeUndefined();
+  });
+});

--- a/projects/common/src/utilities/operations/operation-utilities.ts
+++ b/projects/common/src/utilities/operations/operation-utilities.ts
@@ -5,3 +5,15 @@ export const sortUnknown = (a: unknown, b: unknown) => {
 
   return String(a).localeCompare(String(b));
 };
+
+export const getDifferenceInDays = (timeParamValue: string | undefined): number | undefined => {
+  if (timeParamValue !== undefined) {
+    const timeRangeArray = /(\d+)-(\d+)/.exec(timeParamValue);
+    const currentDate = new Date();
+    const searchStartDate = new Date(+timeRangeArray![1]);
+
+    return currentDate.getDate() - searchStartDate.getDate();
+  }
+
+  return timeParamValue;
+};


### PR DESCRIPTION
## Description
The changes include `rudderstack` api payload fixes.
1. [JIRA](https://razorpay.atlassian.net/browse/OBSV-1177?atlOrigin=eyJpIjoiMjEyMGYwNzRmZDQ4NGQzY2E4MmQ1OThkNWRjZTc0ODQiLCJwIjoiaiJ9) | `userInfo` property should have the value returned from `/user-info` api call. The solution was to store the data in `local-storage` so that the data is not flushed out everytime the page is getting refreshed. Also, the api call is being cancelled if the data is already present in `local-storage`. 
2. [JIRA](https://razorpay.atlassian.net/browse/OBSV-1178?atlOrigin=eyJpIjoiZmRhNGI4OWIxM2YwNDY2YzkxODlhYjJhZjFmMjExNzIiLCJwIjoiaiJ9) | `diffInDays` should be provided when custom time range is selected. It is the no. of days between current time and the start time provided in the custom time range.

### Testing
Tested in local

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules