### PR TITLE
fix: GroupBy panels with interval none not getting displayed on dashboard

### DIFF
--- a/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel-edit/custom-dashboard-panel-edit.component.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel-edit/custom-dashboard-panel-edit.component.ts
@@ -1,17 +1,18 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { isEqualIgnoreFunctions, NavigationService } from '@hypertrace/common';
-import { ButtonRole, Filter, InputAppearance, ToggleItem } from '@hypertrace/components';
 import { cloneDeep } from 'lodash-es';
-import { ExplorerVisualizationMetricDataSourceModel } from 'projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-metric-data-source.model';
 import { EMPTY, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import { distinctUntilChanged, switchMap } from 'rxjs/operators';
+
+import { isEqualIgnoreFunctions, NavigationService } from '@hypertrace/common';
+import { ButtonRole, Filter, InputAppearance, ToggleItem } from '@hypertrace/components';
 import {
   ExploreRequestState,
   ExploreVisualizationRequest
 } from '../../../shared/components/explore-query-editor/explore-visualization-builder';
 import { LegendPosition } from '../../../shared/components/legend/legend.component';
 import { ExplorerVisualizationCartesianDataSourceModel } from '../../../shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model';
+import { ExplorerVisualizationMetricDataSourceModel } from '../../../shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-metric-data-source.model';
 import { AttributeMetadata } from '../../../shared/graphql/model/metadata/attribute-metadata';
 import { ObservabilityTraceType } from '../../../shared/graphql/model/schema/observability-traces';
 import { SPAN_SCOPE } from '../../../shared/graphql/model/schema/span';
@@ -187,7 +188,8 @@ export class CustomDashboardPanelEditComponent {
           children: request.series?.map(seriesObject => ({
             type: 'metric-display-widget',
             title: `${seriesObject.specification.name} ${seriesObject.specification.aggregation}`,
-            subscript: seriesObject.specification.name === 'duration' ? 'ms' : undefined
+            subscript: seriesObject.specification.name === 'duration' ? 'ms' : undefined,
+            'metric-key': seriesObject.specification.resultAlias()
           }))
         },
         onReady: dashboard => {

--- a/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel/custom-dashboard-panel.component.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel/custom-dashboard-panel.component.ts
@@ -102,7 +102,6 @@ export class CustomDashboardPanelComponent implements OnInit {
     this.panel!.series = this.tryDecodeExploreSeries(this.panel!.series);
 
     if (this.panel?.interval !== 'AUTO' && this.panel?.interval !== undefined) {
-      this.panel.interval = this.panel.interval;
       this.panel.interval = new TimeDuration(this.panel.interval.value, this.panel.interval.unit);
     }
 

--- a/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel/custom-dashboard-panel.component.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboard-panel/custom-dashboard-panel.component.ts
@@ -84,6 +84,7 @@ export class CustomDashboardPanelComponent implements OnInit {
   public visualizationDashboard!: ExplorerGeneratedDashboard;
   public expanded: boolean = true;
   public currentContext: ToggleItem = {};
+
   public readonly contextItems: ToggleItem<string>[] = [
     {
       label: 'Traces',
@@ -94,12 +95,15 @@ export class CustomDashboardPanelComponent implements OnInit {
       value: SPAN_SCOPE
     }
   ];
+
   public constructor(private readonly exploreVisualizationBuilder: ExploreVisualizationBuilder) {}
+
   public ngOnInit(): void {
     this.panel!.series = this.tryDecodeExploreSeries(this.panel!.series);
-    if (this.panel?.interval !== 'AUTO') {
-      this.panel!.interval = this.panel!.interval;
-      this.panel!.interval = new TimeDuration(this.panel!.interval.value, this.panel!.interval.unit);
+
+    if (this.panel?.interval !== 'AUTO' && this.panel?.interval !== undefined) {
+      this.panel.interval = this.panel.interval;
+      this.panel.interval = new TimeDuration(this.panel.interval.value, this.panel.interval.unit);
     }
 
     const request = this.exploreVisualizationBuilder.buildRequest(this.panel!);
@@ -107,6 +111,7 @@ export class CustomDashboardPanelComponent implements OnInit {
     this.visualizationDashboard = this.buildVisualizationDashboard(request);
     this.currentContext = this.contextItems.find(i => i.value === this.panel?.context)!;
   }
+
   private tryDecodeExploreSeries(series: ExploreSeries[]): ExploreSeries[] | [] {
     return series.map(singleSeries => ({
       specification: new ExploreSpecificationBuilder().exploreSpecificationForKey(
@@ -133,18 +138,24 @@ export class CustomDashboardPanelComponent implements OnInit {
   public onExpandedChange(expanded: boolean): void {
     this.expanded = expanded;
   }
+
   public onPanelEdit(event: MouseEvent): void {
     event.stopPropagation();
     this.editPanel.emit(this.panel?.id);
   }
+
   public onPanelDelete(event: MouseEvent): void {
     event.stopPropagation();
     this.deletePanel.emit({ panelName: this.panel!.name, panelId: this.panel!.id });
   }
+
   public onPanelClone(event: MouseEvent): void {
     /*
-      need to add stopPropagation since these buttons are in the panel header component, if we dont stop the panel collapse would be triggered which would minimise the panel. Hence we don't want the click event to propagate to the header
-    */
+     * Need to add stopPropagation since these buttons are in the panel
+     * header component. If we dont stop the panel collapse would be
+     * triggered which would minimise the panel. Hence we don't want the
+     * click event to propagate to the header.
+     */
     event.stopPropagation();
     this.clonePanel.emit({ panelName: this.panel!.name, panelId: this.panel!.id });
   }

--- a/projects/observability/src/pages/custom-dashboards/custom-dashboard-store.service.test.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboard-store.service.test.ts
@@ -1,0 +1,27 @@
+import { CustomDashboardStoreService, PanelData } from './custom-dashboard-store.service';
+
+describe('CustomDashboardStoreService', () => {
+  let service: CustomDashboardStoreService;
+  beforeEach(() => {
+    service = new CustomDashboardStoreService();
+  });
+
+  test('set and get dashboard data', () => {
+    service.set('1', { id: '2', name: 'd1', panels: [] });
+    expect(service.get('1').name).toBe('d1');
+  });
+
+  test('hasKey', () => {
+    expect(service.hasKey('1')).toBeFalsy();
+    service.set('1', { id: '2', name: 'd1', panels: [] });
+    expect(service.hasKey('1')).toBeTruthy();
+  });
+
+  test('addPanel and getPanel', () => {
+    service.set('1', { id: '2', name: 'd1', panels: [] });
+    expect(service.getPanel('1', '3')).toBeUndefined();
+
+    service.addPanel('1', { id: '3', name: 'panel1' } as PanelData); // tslint:disable-line: no-object-literal-type-assertion
+    expect(service.getPanel('1', '3')?.name).toBe('panel1');
+  });
+});

--- a/projects/observability/src/pages/custom-dashboards/custom-dashboard-store.service.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboard-store.service.ts
@@ -60,13 +60,15 @@ export interface DashboardData {
   panels: PanelData[];
   ownerId?: number;
 }
+
 export interface PanelData extends ExploreRequestState {
   id: string;
   name: string;
   json: ModelJson;
   isRealtime?: boolean;
-  interval: PanelInterval | 'AUTO';
+  interval: PanelInterval | 'AUTO' | undefined;
 }
+
 export interface PanelInterval extends TimeDuration {
   value: number;
   unit: TimeUnit;

--- a/projects/observability/src/pages/custom-dashboards/custom-dashboards.component.ts
+++ b/projects/observability/src/pages/custom-dashboards/custom-dashboards.component.ts
@@ -100,6 +100,7 @@ export class CustomDashboardListComponent {
       onClick: (row: CustomDashboardTableRow, _column) => this.deleteDashboard(row.id)
     }
   ];
+
   public constructor(
     private readonly customDashboardService: CustomDashboardService,
     private readonly userPreferenceService: UserPreferenceService,
@@ -176,7 +177,10 @@ export class CustomDashboardListComponent {
   }
   public onPaginationChange(options: PageEvent): void {
     const pageOptions = { ...options };
-    // Since HUS page number starts with 1 but ht-paginator has default value set as 0 hence incrementing
+    /*
+     * Since Hypertrace User Service page number starts with 1 but
+     * ht-paginator has default value set as 0 hence incrementing
+     */
     pageOptions.pageIndex += 1;
     this.setupDataSource(pageOptions);
   }


### PR DESCRIPTION
## Description

[Jira][1]

This fixes the bug where Interval None field didn't show any chart when Group By is applied.
The combination with Interval & Group By both None is still not working and will be fixed in a follow-up PR.

### Testing

Steps to test:
- Go to [stage environment][2]
- Create custom dashboard
- Apply a Group By and set Interval to "None"
- Save the panel

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

[1]: https://razorpay.atlassian.net/browse/OBSV-1179
[2]: https://hypertrace.concierge.stage.razorpay.in/custom-dashboards/my-dashboards?time=1h