### PR TITLE
feat: optimize graphql query according to columns displayed

### DIFF
--- a/projects/observability/src/pages/apis/endpoints/endpoint-list.dashboard.ts
+++ b/projects/observability/src/pages/apis/endpoints/endpoint-list.dashboard.ts
@@ -67,7 +67,8 @@ export const endpointListDashboard: DashboardDefaultConfiguration = {
               type: 'metric-aggregation',
               metric: 'duration',
               aggregation: MetricAggregationType.P99
-            }
+            },
+            visible: false
           },
           {
             type: 'table-widget-column',
@@ -77,7 +78,8 @@ export const endpointListDashboard: DashboardDefaultConfiguration = {
               type: 'metric-aggregation',
               metric: 'errorCount',
               aggregation: MetricAggregationType.AvgrateSecond
-            }
+            },
+            visible: false
           },
           {
             type: 'table-widget-column',
@@ -87,7 +89,8 @@ export const endpointListDashboard: DashboardDefaultConfiguration = {
               type: 'metric-aggregation',
               metric: 'numCalls',
               aggregation: MetricAggregationType.AvgrateSecond
-            }
+            },
+            visible: false
           },
           {
             type: 'table-widget-column',
@@ -108,7 +111,8 @@ export const endpointListDashboard: DashboardDefaultConfiguration = {
               type: 'metric-aggregation',
               metric: 'endTime',
               aggregation: MetricAggregationType.Max
-            }
+            },
+            visible: false
           }
         ],
         data: {

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.test.ts
@@ -99,7 +99,7 @@ describe('Entity table data source model', () => {
       expect.objectContaining({
         requestType: ENTITIES_GQL_REQUEST,
         entityType: 'SERVICE',
-        properties: [expect.objectContaining({ name: 'name' }), expect.objectContaining({ name: 'duration' })],
+        properties: [],
         limit: 100,
         offset: 0,
         sort: {
@@ -148,7 +148,7 @@ describe('Entity table data source model', () => {
       expect.objectContaining({
         requestType: ENTITIES_GQL_REQUEST,
         entityType: 'API',
-        properties: [expect.objectContaining({ name: 'name' }), expect.objectContaining({ name: 'duration' })],
+        properties: [],
         limit: 40,
         offset: 0,
         sort: {

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
@@ -94,7 +94,10 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
     return {
       requestType: ENTITIES_GQL_REQUEST,
       entityType: this.entityType,
-      properties: request.columns.map(column => column.specification).concat(...this.additionalSpecifications),
+      properties: request.columns
+        .filter(column => column.visible)
+        .map(column => column.specification)
+        .concat(...this.additionalSpecifications),
       limit: this.limit ?? request.position.limit * 2, // Prefetch 2 pages,
       offset: offset,
       sort: sort,


### PR DESCRIPTION
## Description
1. Show only `Name` and `Service` columns in API Endpoints for faster data load.
2. Filter the Graphql query according to the columns displayed in UI for faster api resolution.

<img width="1506" alt="Screenshot 2022-12-28 at 12 48 14 PM" src="https://user-images.githubusercontent.com/45780866/209774144-f78a0268-b5bd-4e54-9bda-4033f88c8845.png">



### Testing
Tested in local

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
