### PR TITLE
Removes case sensitive filtering for `LIKE` operator | Change order of endpoints list to `DESC` again

### DIFF
--- a/projects/observability/src/pages/apis/endpoints/endpoint-list.dashboard.ts
+++ b/projects/observability/src/pages/apis/endpoints/endpoint-list.dashboard.ts
@@ -45,7 +45,7 @@ export const endpointListDashboard: DashboardDefaultConfiguration = {
             value: {
               type: 'entity-specification'
             },
-            sort: TableSortDirection.Ascending
+            sort: TableSortDirection.Descending
           },
           {
             type: 'table-widget-column',

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
@@ -207,11 +207,9 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
       case FilterOperator.Equals:
         return rows.filter(eachRow => ((eachRow[actualKeyNameInRows] as Entity).name as string) === tableFilter.value);
       case FilterOperator.Like:
-        const regexExp = new RegExp((tableFilter.value as string).toLowerCase());
+        const regexExp = new RegExp(tableFilter.value as string, 'i');
 
-        return rows.filter(eachRow =>
-          regexExp.test(((eachRow[actualKeyNameInRows] as Entity).name as string).toLowerCase())
-        );
+        return rows.filter(eachRow => regexExp.test((eachRow[actualKeyNameInRows] as Entity).name as string));
       case FilterOperator.In:
         return rows.filter(eachRow =>
           (tableFilter.value as string[]).includes((eachRow[actualKeyNameInRows] as Entity).name as string)

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
@@ -207,9 +207,11 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
       case FilterOperator.Equals:
         return rows.filter(eachRow => ((eachRow[actualKeyNameInRows] as Entity).name as string) === tableFilter.value);
       case FilterOperator.Like:
-        const regexExp = new RegExp(tableFilter.value as string);
+        const regexExp = new RegExp((tableFilter.value as string).toLowerCase());
 
-        return rows.filter(eachRow => regexExp.test((eachRow[actualKeyNameInRows] as Entity).name as string));
+        return rows.filter(eachRow =>
+          regexExp.test(((eachRow[actualKeyNameInRows] as Entity).name as string).toLowerCase())
+        );
       case FilterOperator.In:
         return rows.filter(eachRow =>
           (tableFilter.value as string[]).includes((eachRow[actualKeyNameInRows] as Entity).name as string)


### PR DESCRIPTION
- Removes case sensitive filtering when `LIKE` operator is used.
- Changes order of API Endpoints list to `DESC` order again.