### PR TITLE
Add higher precision for `ms` in Waterfall view

### DIFF
--- a/projects/components/src/sequence/renderer/sequence-bar-renderer.service.ts
+++ b/projects/components/src/sequence/renderer/sequence-bar-renderer.service.ts
@@ -145,7 +145,7 @@ export class SequenceBarRendererService {
       )
       .attr('dy', '.82em')
       .style('font-size', '14px')
-      .text(dataRow => `${dataRow.end - dataRow.start}${options.unit !== undefined ? options.unit : ''}`);
+      .text(dataRow => `${dataRow.duration}${options.unit !== undefined ? options.unit : ''}`);
   }
 
   private drawPlotTopBorder(

--- a/projects/components/src/sequence/sequence-chart.component.test.ts
+++ b/projects/components/src/sequence/sequence-chart.component.test.ts
@@ -23,6 +23,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -31,6 +32,7 @@ describe('Sequence Chart component', () => {
         id: '2',
         start: 1569357461346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 2',
         color: 'green',
         markers: []
@@ -39,6 +41,7 @@ describe('Sequence Chart component', () => {
         id: '3',
         start: 1569357462346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 3',
         color: 'green',
         markers: []
@@ -47,6 +50,7 @@ describe('Sequence Chart component', () => {
         id: '4',
         start: 1569357463346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 4',
         color: 'green',
         markers: []
@@ -84,7 +88,7 @@ describe('Sequence Chart component', () => {
       // Test Bar text
       const barValueText = dataRow.querySelector('.bar-value-text');
       expect(barValueText).toExist();
-      expect(barValueText).toHaveText(`${segmentsData[index].end - segmentsData[index].start}`);
+      expect(barValueText).toHaveText(`${segmentsData[index].duration}`);
     });
   });
 
@@ -94,6 +98,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -112,7 +117,7 @@ describe('Sequence Chart component', () => {
     // Test Bar text
     const barValueText = dataRow!.querySelector('.bar-value-text');
     expect(barValueText).toExist();
-    expect(barValueText).toHaveText(`${segmentsData[0].end - segmentsData[0].start}ms`);
+    expect(barValueText).toHaveText(`${segmentsData[0].duration}ms`);
   });
 
   test('should render with correct row height', () => {
@@ -121,6 +126,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -144,6 +150,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: [
@@ -175,6 +182,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -201,6 +209,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -224,6 +233,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -232,6 +242,7 @@ describe('Sequence Chart component', () => {
         id: '2',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 2',
         color: 'green',
         markers: []
@@ -270,6 +281,7 @@ describe('Sequence Chart component', () => {
         id: '1',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 1',
         color: 'blue',
         markers: []
@@ -278,6 +290,7 @@ describe('Sequence Chart component', () => {
         id: '2',
         start: 1569357460346,
         end: 1569357465346,
+        duration: 5000.0,
         label: 'Segment 2',
         color: 'green',
         markers: []

--- a/projects/components/src/sequence/sequence-chart.component.ts
+++ b/projects/components/src/sequence/sequence-chart.component.ts
@@ -119,6 +119,7 @@ export class SequenceChartComponent implements OnChanges {
       id: segment.id,
       start: segment.start - minStart,
       end: segment.end - minStart,
+      duration: segment.duration,
       color: segment.color,
       markers: segment.markers
         .map((marker: Marker) => ({ ...marker, markerTime: marker.markerTime - minStart }))

--- a/projects/components/src/sequence/sequence.ts
+++ b/projects/components/src/sequence/sequence.ts
@@ -8,6 +8,7 @@ export interface SequenceSegment {
   end: number;
   color: string;
   markers: Marker[];
+  duration?: number;
 }
 
 export interface Marker {

--- a/projects/observability/src/shared/dashboard/data/graphql/waterfall/api-trace-waterfall-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/waterfall/api-trace-waterfall-data-source.model.test.ts
@@ -81,6 +81,9 @@ describe('Api Trace Waterfall data source model', () => {
               name: 'duration'
             }),
             expect.objectContaining({
+              name: 'durationDouble'
+            }),
+            expect.objectContaining({
               name: 'endTime'
             }),
             expect.objectContaining({
@@ -153,6 +156,9 @@ describe('Api Trace Waterfall data source model', () => {
               name: 'duration'
             }),
             expect.objectContaining({
+              name: 'durationDouble'
+            }),
+            expect.objectContaining({
               name: 'endTime'
             }),
             expect.objectContaining({
@@ -212,6 +218,7 @@ describe('Api Trace Waterfall data source model', () => {
               startTime: 1571339873680,
               endTime: 1571339873680,
               duration: 1,
+              durationDouble: 1.0,
               displayEntityName: 'Entity Name 1',
               displaySpanName: 'Span Name 1',
               protocolName: 'Protocol Name 1',
@@ -225,6 +232,7 @@ describe('Api Trace Waterfall data source model', () => {
               startTime: 1571339873680,
               endTime: 1571339873680,
               duration: 2,
+              durationDouble: 2.0,
               displayEntityName: 'Entity Name 2',
               displaySpanName: 'Span Name 2',
               protocolName: 'Protocol Name 2',
@@ -243,7 +251,7 @@ describe('Api Trace Waterfall data source model', () => {
             startTime: 1571339873680,
             endTime: 1571339873680,
             duration: {
-              value: 1,
+              value: 1.0,
               units: 'ms'
             },
             serviceName: 'Entity Name 1',
@@ -260,7 +268,7 @@ describe('Api Trace Waterfall data source model', () => {
             startTime: 1571339873680,
             endTime: 1571339873680,
             duration: {
-              value: 2,
+              value: 2.0,
               units: 'ms'
             },
             serviceName: 'Entity Name 2',

--- a/projects/observability/src/shared/dashboard/data/graphql/waterfall/api-trace-waterfall-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/waterfall/api-trace-waterfall-data-source.model.ts
@@ -55,6 +55,7 @@ export class ApiTraceWaterfallDataSourceModel extends GraphQlDataSourceModel<Wat
       'displayEntityName',
       'displaySpanName',
       'duration',
+      'durationDouble',
       'endTime',
       'parentSpanId',
       'protocolName',
@@ -107,7 +108,7 @@ export class ApiTraceWaterfallDataSourceModel extends GraphQlDataSourceModel<Wat
       startTime: span.startTime as number,
       endTime: span.endTime as number,
       duration: {
-        value: span.duration as number,
+        value: span.durationDouble as number,
         units: duration.units
       },
       serviceName: span.displayEntityName as string,

--- a/projects/observability/src/shared/dashboard/data/graphql/waterfall/trace-waterfall-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/waterfall/trace-waterfall-data-source.model.test.ts
@@ -77,6 +77,9 @@ describe('Trace Waterfall data source model', () => {
               name: 'duration'
             }),
             expect.objectContaining({
+              name: 'durationDouble'
+            }),
+            expect.objectContaining({
               name: 'endTime'
             }),
             expect.objectContaining({
@@ -148,6 +151,9 @@ describe('Trace Waterfall data source model', () => {
               name: 'duration'
             }),
             expect.objectContaining({
+              name: 'durationDouble'
+            }),
+            expect.objectContaining({
               name: 'endTime'
             }),
             expect.objectContaining({
@@ -211,6 +217,7 @@ describe('Trace Waterfall data source model', () => {
               startTime: 1571339873680,
               endTime: 1571339873680,
               duration: 1,
+              durationDouble: 1.0,
               displaySpanName: 'Span Name 1',
               serviceName: 'Service Name 1',
               type: SpanType.Entry,
@@ -223,6 +230,7 @@ describe('Trace Waterfall data source model', () => {
               startTime: 1571339873680,
               endTime: 1571339873680,
               duration: 2,
+              durationDouble: 2.0,
               displaySpanName: 'Span Name 2',
               serviceName: 'Service Name 2',
               type: SpanType.Exit,
@@ -240,7 +248,7 @@ describe('Trace Waterfall data source model', () => {
             startTime: 1571339873680,
             endTime: 1571339873680,
             duration: {
-              value: 1,
+              value: 1.0,
               units: 'ms'
             },
             apiName: 'Span Name 1',
@@ -257,7 +265,7 @@ describe('Trace Waterfall data source model', () => {
             startTime: 1571339873680,
             endTime: 1571339873680,
             duration: {
-              value: 2,
+              value: 2.0,
               units: 'ms'
             },
             apiName: 'Span Name 2',

--- a/projects/observability/src/shared/dashboard/data/graphql/waterfall/trace-waterfall-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/waterfall/trace-waterfall-data-source.model.ts
@@ -54,6 +54,7 @@ export class TraceWaterfallDataSourceModel extends GraphQlDataSourceModel<Waterf
   protected readonly spanSpecifications: Specification[] = [
     this.specificationBuilder.attributeSpecificationForKey('displaySpanName'),
     this.specificationBuilder.attributeSpecificationForKey('duration'),
+    this.specificationBuilder.attributeSpecificationForKey('durationDouble'),
     this.specificationBuilder.attributeSpecificationForKey('endTime'),
     this.specificationBuilder.attributeSpecificationForKey('parentSpanId'),
     this.specificationBuilder.attributeSpecificationForKey('serviceName'),
@@ -105,7 +106,7 @@ export class TraceWaterfallDataSourceModel extends GraphQlDataSourceModel<Waterf
       startTime: span.startTime as number,
       endTime: span.endTime as number,
       duration: {
-        value: span.duration as number,
+        value: span.durationDouble as number,
         units: duration.units
       },
       serviceName: span.serviceName as string,

--- a/projects/observability/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.service.ts
+++ b/projects/observability/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.service.ts
@@ -91,6 +91,7 @@ export class WaterfallChartService {
           start: node.startTime,
           end: node.endTime,
           color: node.color!,
+          duration: node.duration.value,
           markers: node.logEvents.map((logEvent: LogEvent) => ({
             id: node.id,
             markerTime: this.dateCoercer.coerce(logEvent.timestamp)!.getTime(),


### PR DESCRIPTION
- Brings an additional field called `durationDouble` from the backend for `spans` call used in waterfall views.
- Adds a new property called `duration` for sequence objects, this is used to render the bar text for each span in the waterfall view.
- For API Endpoints and Traces, reads the value from `durationDouble`, which is a new attribute added for reading duration with higher precision and forwards the same to the sequence-chart.component`, so that the text in the bar can be read from this field. 
 

Example Image

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/56739130/210734455-19484fa7-d031-412b-80b2-b6b9b48fed01.png">
